### PR TITLE
Aggregate duplicated results

### DIFF
--- a/reporting/report.go
+++ b/reporting/report.go
@@ -2,7 +2,7 @@ package reporting
 
 import (
 	"fmt"
-	"strings"
+	"github.com/checkmarx/2ms/secrets"
 )
 
 type Report struct {
@@ -13,6 +13,7 @@ type Report struct {
 
 type Secret struct {
 	ID          string
+	Links       []string
 	Description string
 	StartLine   int
 	EndLine     int
@@ -24,6 +25,27 @@ type Secret struct {
 func Init() *Report {
 	return &Report{
 		Results: make(map[string][]Secret),
+	}
+}
+
+func (r *Report) AddSecret(finding secrets.Finding) {
+	done := false
+
+	// If secret already exists, just add the link of new finding
+	if len(r.Results[finding.ID]) > 0 {
+		for i, s := range r.Results[finding.ID] {
+			if s.Value == finding.Secret {
+				s := &r.Results[finding.ID][i]
+				s.Links = append(s.Links, finding.Source)
+				done = true
+				break
+			}
+		}
+	}
+	// If secret don't exist on a specific source or if source doesn't exist just create the secret
+	if !done {
+		secret := Secret{ID: finding.ID, Links: []string{finding.Source}, Description: finding.Description, StartLine: finding.StartLine, EndLine: finding.EndLine, StartColumn: finding.StartColumn, EndColumn: finding.EndColumn, Value: finding.Secret}
+		r.Results[finding.ID] = append(r.Results[finding.ID], secret)
 	}
 }
 
@@ -41,20 +63,17 @@ func (r *Report) ShowReport() {
 
 func (r *Report) generateResultsReport() {
 	for source, secrets := range r.Results {
-		itemLink := getItemId(source)
-		fmt.Printf("- Item ID: %s\n", itemLink)
+		fmt.Printf("- Item ID: %s\n", source)
 		fmt.Printf(" - Item Link: %s\n", source)
 		fmt.Println("  - Secrets:")
 		for _, secret := range secrets {
 			fmt.Printf("   - Type: %s\n", secret.Description)
+			fmt.Printf("    - Links: %d\n", len(secret.Links))
+			for _, link := range secret.Links {
+				fmt.Printf("      - %s\n", link)
+			}
 			fmt.Printf("    - Location: %d-%d\n", secret.StartColumn, secret.EndColumn)
 			fmt.Printf("    - Value: %.40s\n", secret.Value)
 		}
 	}
-}
-
-func getItemId(fullPath string) string {
-	itemLinkStrings := strings.Split(fullPath, "/")
-	itemLink := itemLinkStrings[len(itemLinkStrings)-1]
-	return itemLink
 }

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -2,7 +2,6 @@ package secrets
 
 import (
 	"github.com/checkmarx/2ms/plugins"
-	"github.com/checkmarx/2ms/reporting"
 	"github.com/zricethezav/gitleaks/v8/cmd/generate/config/rules"
 	"github.com/zricethezav/gitleaks/v8/config"
 	"github.com/zricethezav/gitleaks/v8/detect"
@@ -18,6 +17,18 @@ type Secrets struct {
 type Rule struct {
 	Rule config.Rule
 	Tags []string
+}
+
+type Finding struct {
+	ID          string
+	Source      string
+	Content     string
+	Description string
+	StartLine   int
+	EndLine     int
+	StartColumn int
+	EndColumn   int
+	Secret      string
 }
 
 const TagApiKey = "api-key"
@@ -57,14 +68,14 @@ func Init(tags []string) *Secrets {
 	}
 }
 
-func (s *Secrets) Detect(secretsChannel chan reporting.Secret, item plugins.Item, wg *sync.WaitGroup) {
+func (s *Secrets) Detect(secretsChannel chan Finding, item plugins.Item, wg *sync.WaitGroup) {
 	defer wg.Done()
 
 	fragment := detect.Fragment{
 		Raw: item.Content,
 	}
-	for _, value := range s.detector.Detect(fragment) {
-		secretsChannel <- reporting.Secret{ID: item.ID, Description: value.Description, StartLine: value.StartLine, StartColumn: value.StartColumn, EndLine: value.EndLine, EndColumn: value.EndColumn, Value: value.Secret}
+	for _, find := range s.detector.Detect(fragment) {
+		secretsChannel <- Finding{ID: item.ID, Source: item.Source, Content: item.Content, Description: find.Description, StartLine: find.StartLine, EndLine: find.EndLine, StartColumn: find.StartColumn, EndColumn: find.EndColumn, Secret: find.Secret}
 	}
 }
 


### PR DESCRIPTION
To make the app suitable to don't show duplicated results some structural changes were applied:

Secrets module will return a Find instead of returning a Secret. Depending on if find already exists or not, the secret will be created.

Now we are mapping the items by the page ID instead of the entire original URL

Secrets now have an array of links containing link for all item versions where secret is present.

Also was made a fix on confluence plugin were query parameters creation was wrong