### PR TITLE
feat: use sub-command for plugins

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -49,7 +49,7 @@ jobs:
       
       - run: make build
       - name: Run docker and check its output
-        run: if docker run -t checkmarx/2ms:latest confluence | grep "confluence URL arg is missing"; then
+        run: if docker run -t checkmarx/2ms:latest confluence --url dump | grep "confluence credentials were not provided"; then
             echo "Docker ran as expected";
           else
             echo "Docker did not run as expected";

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -38,7 +38,7 @@ jobs:
       
       - run: make build
       - name: Run docker and check its output
-        run: if docker run -t checkmarx/2ms:latest confluence --url dump | grep "confluence credentials were not provided"; then
+        run: if docker run -t checkmarx/2ms:latest --version | grep "2ms version"; then
             echo "Docker ran as expected";
           else
             echo "Docker did not run as expected";

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -49,7 +49,7 @@ jobs:
       
       - run: make build
       - name: Run docker and check its output
-        run: if docker run -t checkmarx/2ms:latest | grep "no scan plugin initialized"; then
+        run: if docker run -t checkmarx/2ms:latest confluence | grep "confluence URL arg is missing"; then
             echo "Docker ran as expected";
           else
             echo "Docker did not run as expected";

--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,9 @@ save: build
 
 run:
 	docker run -it $(image_name) $(ARGS)
+
+# To run golangci-lint, you need to install it first: https://golangci-lint.run/usage/install/#local-installation
+lint:
+	golangci-lint run -v -E gofmt --timeout=5m
+lint-fix:
+	golangci-lint run -v -E gofmt --fix --timeout=5m

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
@@ -18,13 +19,13 @@ import (
 
 const timeSleepInterval = 50
 
+var Version = "0.0.0"
+
 var rootCmd = &cobra.Command{
 	Use:     "2ms",
 	Short:   "2ms Secrets Detection",
 	Version: Version,
 }
-
-var Version = ""
 
 var allPlugins = []plugins.IPlugin{
 	&plugins.ConfluencePlugin{},
@@ -75,7 +76,10 @@ func Execute() {
 	rootCmd.PersistentPostRun = postRun
 
 	for _, plugin := range allPlugins {
-		subCommand := plugin.DefineCommand(channels)
+		subCommand, err := plugin.DefineCommand(channels)
+		if err != nil {
+			log.Fatal().Msg(fmt.Sprintf("error while defining command for plugin %s: %s", plugin.GetName(), err.Error()))
+		}
 		rootCmd.AddCommand(subCommand)
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -71,10 +71,11 @@ func Execute() {
 	rootCmd.PersistentFlags().StringSlice("tags", []string{"all"}, "select rules to be applied")
 	rootCmd.PersistentFlags().StringP("log-level", "", "info", "log level (trace, debug, info, warn, error, fatal)")
 
+	rootCmd.PersistentPreRun = preRun
+	rootCmd.PersistentPostRun = postRun
+
 	for _, plugin := range allPlugins {
 		subCommand := plugin.DefineCommand(channels)
-		subCommand.PreRun = preRun
-		subCommand.PostRun = postRun
 		rootCmd.AddCommand(subCommand)
 	}
 

--- a/plugins/confluence.go
+++ b/plugins/confluence.go
@@ -13,13 +13,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const argConfluence = "confluence"
-const argConfluenceSpaces = "confluence-spaces"
-const argConfluenceUsername = "confluence-username"
-const argConfluenceToken = "confluence-token"
-const argConfluenceHistory = "history"
-const confluenceDefaultWindow = 25
-const confluenceMaxRequests = 500
+const (
+	argUrl                  = "url"
+	argSpaces               = "spaces"
+	argUsername             = "username"
+	argToken                = "token"
+	argHistory              = "history"
+	confluenceDefaultWindow = 25
+	confluenceMaxRequests   = 500
+)
 
 type ConfluencePlugin struct {
 	Plugin
@@ -41,37 +43,37 @@ func (p *ConfluencePlugin) DefineSubCommand(cmd *cobra.Command) *cobra.Command {
 	}
 
 	flags := confluenceCmd.Flags()
-	flags.StringP(argConfluence, "", "", "scan confluence url")
-	flags.StringArray(argConfluenceSpaces, []string{}, "confluence spaces")
-	flags.StringP(argConfluenceUsername, "", "", "confluence username or email")
-	flags.StringP(argConfluenceToken, "", "", "confluence token")
-	flags.BoolP(argConfluenceHistory, "", false, "scan pages history")
+	flags.StringP(argUrl, "", "", "confluence url")
+	flags.StringArray(argSpaces, []string{}, "confluence spaces")
+	flags.StringP(argUsername, "", "", "confluence username or email")
+	flags.StringP(argToken, "", "", "confluence token")
+	flags.BoolP(argHistory, "", false, "scan pages history")
 
 	return confluenceCmd
 }
 
 func (p *ConfluencePlugin) Initialize(cmd *cobra.Command) error {
 	flags := cmd.Flags()
-	confluenceUrl, _ := flags.GetString(argConfluence)
-	if confluenceUrl == "" {
+	url, _ := flags.GetString(argUrl)
+	if url == "" {
 		return errors.New("confluence URL arg is missing. Plugin initialization failed")
 	}
 
-	confluenceUrl = strings.TrimRight(confluenceUrl, "/")
+	url = strings.TrimRight(url, "/")
 
-	confluenceSpaces, _ := flags.GetStringArray(argConfluenceSpaces)
-	confluenceUsername, _ := flags.GetString(argConfluenceUsername)
-	confluenceToken, _ := flags.GetString(argConfluenceToken)
-	runHistory, _ := flags.GetBool(argConfluenceHistory)
+	spaces, _ := flags.GetStringArray(argSpaces)
+	username, _ := flags.GetString(argUsername)
+	token, _ := flags.GetString(argToken)
+	runHistory, _ := flags.GetBool(argHistory)
 
-	if confluenceUsername == "" || confluenceToken == "" {
+	if username == "" || token == "" {
 		log.Warn().Msg("confluence credentials were not provided. The scan will be made anonymously only for the public pages")
 	}
 
-	p.Token = confluenceToken
-	p.Username = confluenceUsername
-	p.URL = confluenceUrl
-	p.Spaces = confluenceSpaces
+	p.Token = token
+	p.Username = username
+	p.URL = url
+	p.Spaces = spaces
 	p.Enabled = true
 	p.History = runHistory
 	p.Limit = make(chan struct{}, confluenceMaxRequests)

--- a/plugins/confluence.go
+++ b/plugins/confluence.go
@@ -47,7 +47,10 @@ func (p *ConfluencePlugin) DefineSubCommand(cmd *cobra.Command) *cobra.Command {
 	flags.StringP(argUsername, "", "", "confluence username or email")
 	flags.StringP(argToken, "", "", "confluence token")
 	flags.BoolP(argHistory, "", false, "scan pages history")
-	confluenceCmd.MarkFlagRequired(argUrl)
+	err := confluenceCmd.MarkFlagRequired(argUrl)
+	if err != nil {
+		log.Fatal().Err(err).Msg("error while marking flag as required")
+	}
 
 	return confluenceCmd
 }

--- a/plugins/confluence.go
+++ b/plugins/confluence.go
@@ -38,14 +38,20 @@ func (p *ConfluencePlugin) GetCredentials() (string, string) {
 	return p.Username, p.Token
 }
 
-func (p *ConfluencePlugin) DefineCommandLineArgs(cmd *cobra.Command) error {
-	flags := cmd.Flags()
+func (p *ConfluencePlugin) DefineCommandLineArgs(cmd *cobra.Command) *cobra.Command {
+	var confluenceCmd = &cobra.Command{
+		Use:   "confluence",
+		Short: "Scan confluence",
+	}
+
+	flags := confluenceCmd.Flags()
 	flags.StringP(argConfluence, "", "", "scan confluence url")
 	flags.StringArray(argConfluenceSpaces, []string{}, "confluence spaces")
 	flags.StringP(argConfluenceUsername, "", "", "confluence username or email")
 	flags.StringP(argConfluenceToken, "", "", "confluence token")
 	flags.BoolP(argConfluenceHistory, "", false, "scan pages history")
-	return nil
+
+	return confluenceCmd
 }
 
 func (p *ConfluencePlugin) Initialize(cmd *cobra.Command) error {
@@ -77,10 +83,8 @@ func (p *ConfluencePlugin) Initialize(cmd *cobra.Command) error {
 }
 
 func (p *ConfluencePlugin) GetItems(items chan Item, errs chan error, wg *sync.WaitGroup) {
-	defer wg.Done()
-
-	go p.getSpacesItems(items, errs, wg)
 	wg.Add(1)
+	go p.getSpacesItems(items, errs, wg)
 }
 
 func (p *ConfluencePlugin) getSpacesItems(items chan Item, errs chan error, wg *sync.WaitGroup) {

--- a/plugins/confluence.go
+++ b/plugins/confluence.go
@@ -30,15 +30,11 @@ type ConfluencePlugin struct {
 	History  bool
 }
 
-func (p *ConfluencePlugin) IsEnabled() bool {
-	return p.Enabled
-}
-
 func (p *ConfluencePlugin) GetCredentials() (string, string) {
 	return p.Username, p.Token
 }
 
-func (p *ConfluencePlugin) DefineCommandLineArgs(cmd *cobra.Command) *cobra.Command {
+func (p *ConfluencePlugin) DefineSubCommand(cmd *cobra.Command) *cobra.Command {
 	var confluenceCmd = &cobra.Command{
 		Use:   "confluence",
 		Short: "Scan confluence",
@@ -83,13 +79,10 @@ func (p *ConfluencePlugin) Initialize(cmd *cobra.Command) error {
 }
 
 func (p *ConfluencePlugin) GetItems(items chan Item, errs chan error, wg *sync.WaitGroup) {
-	wg.Add(1)
-	go p.getSpacesItems(items, errs, wg)
+	p.getSpacesItems(items, errs, wg)
 }
 
 func (p *ConfluencePlugin) getSpacesItems(items chan Item, errs chan error, wg *sync.WaitGroup) {
-	defer wg.Done()
-
 	spaces, err := p.getSpaces()
 	if err != nil {
 		errs <- err

--- a/plugins/confluence.go
+++ b/plugins/confluence.go
@@ -35,7 +35,7 @@ func (p *ConfluencePlugin) GetCredentials() (string, string) {
 	return p.Username, p.Token
 }
 
-func (p *ConfluencePlugin) DefineSubCommand(cmd *cobra.Command) *cobra.Command {
+func (p *ConfluencePlugin) DefineCommand(channels Channels) *cobra.Command {
 	var confluenceCmd = &cobra.Command{
 		Use:   "confluence",
 		Short: "Scan confluence",
@@ -50,6 +50,15 @@ func (p *ConfluencePlugin) DefineSubCommand(cmd *cobra.Command) *cobra.Command {
 	err := confluenceCmd.MarkFlagRequired(argUrl)
 	if err != nil {
 		log.Fatal().Err(err).Msg("error while marking flag as required")
+	}
+
+	confluenceCmd.Run = func(cmd *cobra.Command, args []string) {
+		err := p.Initialize(cmd)
+		if err != nil {
+			log.Fatal().Msg(err.Error())
+		}
+
+		p.GetItems(channels.Items, channels.Errors, channels.WaitGroup)
 	}
 
 	return confluenceCmd

--- a/plugins/confluence.go
+++ b/plugins/confluence.go
@@ -2,7 +2,6 @@ package plugins
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -48,15 +47,16 @@ func (p *ConfluencePlugin) DefineSubCommand(cmd *cobra.Command) *cobra.Command {
 	flags.StringP(argUsername, "", "", "confluence username or email")
 	flags.StringP(argToken, "", "", "confluence token")
 	flags.BoolP(argHistory, "", false, "scan pages history")
+	confluenceCmd.MarkFlagRequired(argUrl)
 
 	return confluenceCmd
 }
 
 func (p *ConfluencePlugin) Initialize(cmd *cobra.Command) error {
 	flags := cmd.Flags()
-	url, _ := flags.GetString(argUrl)
-	if url == "" {
-		return errors.New("confluence URL arg is missing. Plugin initialization failed")
+	url, err := flags.GetString(argUrl)
+	if err != nil {
+		return err
 	}
 
 	url = strings.TrimRight(url, "/")
@@ -74,7 +74,6 @@ func (p *ConfluencePlugin) Initialize(cmd *cobra.Command) error {
 	p.Username = username
 	p.URL = url
 	p.Spaces = spaces
-	p.Enabled = true
 	p.History = runHistory
 	p.Limit = make(chan struct{}, confluenceMaxRequests)
 	return nil

--- a/plugins/discord.go
+++ b/plugins/discord.go
@@ -48,8 +48,14 @@ func (p *DiscordPlugin) DefineCommand(channels Channels) *cobra.Command {
 	flags.Duration(fromDateFlag, defaultDateFrom, "discord from date")
 	flags.Int(messagesCountFlag, 0, "discord messages count")
 
-	discordCmd.MarkFlagRequired(tokenFlag)
-	discordCmd.MarkFlagRequired(serversFlag)
+	err := discordCmd.MarkFlagRequired(tokenFlag)
+	if err != nil {
+		log.Fatal().Err(err).Msg("error while marking flag as required")
+	}
+	err = discordCmd.MarkFlagRequired(serversFlag)
+	if err != nil {
+		log.Fatal().Err(err).Msg("error while marking flag as required")
+	}
 
 	discordCmd.Run = func(cmd *cobra.Command, args []string) {
 		err := p.Initialize(cmd)

--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -17,8 +17,12 @@ type Plugin struct {
 	Limit chan struct{}
 }
 
+type Channels struct {
+	Items     chan Item
+	Errors    chan error
+	WaitGroup *sync.WaitGroup
+}
+
 type IPlugin interface {
-	DefineSubCommand(cmd *cobra.Command) *cobra.Command
-	Initialize(cmd *cobra.Command) error
-	GetItems(chan Item, chan error, *sync.WaitGroup)
+	DefineCommand(channels Channels) *cobra.Command
 }

--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -1,8 +1,9 @@
 package plugins
 
 import (
-	"github.com/spf13/cobra"
 	"sync"
+
+	"github.com/spf13/cobra"
 )
 
 type Item struct {
@@ -18,7 +19,7 @@ type Plugin struct {
 }
 
 type IPlugin interface {
-	DefineCommandLineArgs(cmd *cobra.Command) error
+	DefineCommandLineArgs(cmd *cobra.Command) *cobra.Command
 	Initialize(cmd *cobra.Command) error
 	GetItems(chan Item, chan error, *sync.WaitGroup)
 	IsEnabled() bool

--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -24,5 +24,6 @@ type Channels struct {
 }
 
 type IPlugin interface {
-	DefineCommand(channels Channels) *cobra.Command
+	GetName() string
+	DefineCommand(channels Channels) (*cobra.Command, error)
 }

--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -19,8 +19,7 @@ type Plugin struct {
 }
 
 type IPlugin interface {
-	DefineCommandLineArgs(cmd *cobra.Command) *cobra.Command
+	DefineSubCommand(cmd *cobra.Command) *cobra.Command
 	Initialize(cmd *cobra.Command) error
 	GetItems(chan Item, chan error, *sync.WaitGroup)
-	IsEnabled() bool
 }

--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -13,9 +13,8 @@ type Item struct {
 }
 
 type Plugin struct {
-	ID      string
-	Enabled bool
-	Limit   chan struct{}
+	ID    string
+	Limit chan struct{}
 }
 
 type IPlugin interface {

--- a/plugins/repository.go
+++ b/plugins/repository.go
@@ -16,7 +16,7 @@ type RepositoryPlugin struct {
 	Path string
 }
 
-func (p *RepositoryPlugin) DefineSubCommand(cmd *cobra.Command) *cobra.Command {
+func (p *RepositoryPlugin) DefineCommand(channels Channels) *cobra.Command {
 	var repositoryCmd = &cobra.Command{
 		Use:   "repository",
 		Short: "Scan repository",
@@ -27,6 +27,15 @@ func (p *RepositoryPlugin) DefineSubCommand(cmd *cobra.Command) *cobra.Command {
 	err := repositoryCmd.MarkFlagRequired(argRepository)
 	if err != nil {
 		log.Fatal().Err(err).Msg("error while marking flag as required")
+	}
+
+	repositoryCmd.Run = func(cmd *cobra.Command, args []string) {
+		err := p.Initialize(cmd)
+		if err != nil {
+			log.Fatal().Msg(err.Error())
+		}
+
+		p.GetItems(channels.Items, channels.Errors, channels.WaitGroup)
 	}
 
 	return repositoryCmd

--- a/plugins/repository.go
+++ b/plugins/repository.go
@@ -1,7 +1,6 @@
 package plugins
 
 import (
-	"errors"
 	"os"
 	"path/filepath"
 	"sync"
@@ -17,25 +16,27 @@ type RepositoryPlugin struct {
 	Path string
 }
 
-func (p *RepositoryPlugin) IsEnabled() bool {
-	return p.Enabled
-}
+func (p *RepositoryPlugin) DefineSubCommand(cmd *cobra.Command) *cobra.Command {
+	var repositoryCmd = &cobra.Command{
+		Use:   "repository",
+		Short: "Scan repository",
+	}
 
-func (p *RepositoryPlugin) DefineCommandLineArgs(cmd *cobra.Command) error {
-	flags := cmd.Flags()
+	flags := repositoryCmd.Flags()
 	flags.String(argRepository, "", "scan repository folder")
-	return nil
+	repositoryCmd.MarkFlagRequired(argRepository)
+
+	return repositoryCmd
 }
 
 func (p *RepositoryPlugin) Initialize(cmd *cobra.Command) error {
 	flags := cmd.Flags()
-	directoryPath, _ := flags.GetString(argRepository)
-	if directoryPath == "" {
-		return errors.New("path to repository missing. Plugin initialization failed")
+	directoryPath, err := flags.GetString(argRepository)
+	if err != nil {
+		return err
 	}
 
 	p.Path = directoryPath
-	p.Enabled = true
 	return nil
 }
 

--- a/plugins/repository.go
+++ b/plugins/repository.go
@@ -24,7 +24,10 @@ func (p *RepositoryPlugin) DefineSubCommand(cmd *cobra.Command) *cobra.Command {
 
 	flags := repositoryCmd.Flags()
 	flags.String(argRepository, "", "scan repository folder")
-	repositoryCmd.MarkFlagRequired(argRepository)
+	err := repositoryCmd.MarkFlagRequired(argRepository)
+	if err != nil {
+		log.Fatal().Err(err).Msg("error while marking flag as required")
+	}
 
 	return repositoryCmd
 }


### PR DESCRIPTION
BREAKING CHANGE: the CLI command and arguments was changed

See the discussion: https://github.com/Checkmarx/2ms/discussions/20#discussioncomment-5647413

I think we don't need to support running *2ms* for multiple plugins at once. It is a rare case and it is confusing the command line arguments.

Instead, I'm proposing using *SubCommand* for each plugin.
