### PR TITLE
infra: remove duplicate lint and run tests

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -6,20 +6,6 @@ on:
       - master
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - uses: actions/setup-go@v4
-        with:
-          go-version: '^1.20'
-
-      - name: Go Linter
-        run: docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:v1.52.0 golangci-lint run -v -E gofmt --timeout=5m
-
   test:
     strategy:
       matrix:
@@ -37,6 +23,9 @@ jobs:
 
       - name: Go Linter
         run: docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:v1.52.0 golangci-lint run -v -E gofmt --timeout=5m
+
+      - name: Go Test
+        run: go test -v ./...
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I noticed in `pr-validation` we are running our linter twice, and not running unit-tests at all.
