### PR TITLE
fix: add helpful output to the help command

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -21,9 +21,15 @@ const timeSleepInterval = 50
 
 var Version = "0.0.0"
 
+const (
+	tagsFlagName     = "tags"
+	logLevelFlagName = "log-level"
+)
+
 var rootCmd = &cobra.Command{
 	Use:     "2ms",
 	Short:   "2ms Secrets Detection",
+	Long:    "2ms Secrets Detection: A tool to detect secrets in public websites and communication services.",
 	Version: Version,
 }
 
@@ -44,7 +50,7 @@ var secretsChan = make(chan reporting.Secret)
 
 func initLog() {
 	zerolog.SetGlobalLevel(zerolog.InfoLevel)
-	ll, err := rootCmd.Flags().GetString("log-level")
+	ll, err := rootCmd.Flags().GetString(logLevelFlagName)
 	if err != nil {
 		log.Fatal().Msg(err.Error())
 	}
@@ -68,15 +74,18 @@ func initLog() {
 
 func Execute() {
 	cobra.OnInitialize(initLog)
-	rootCmd.PersistentFlags().BoolP("all", "", true, "scan all plugins")
-	rootCmd.PersistentFlags().StringSlice("tags", []string{"all"}, "select rules to be applied")
-	rootCmd.PersistentFlags().StringP("log-level", "", "info", "log level (trace, debug, info, warn, error, fatal)")
+	rootCmd.PersistentFlags().StringSlice(tagsFlagName, []string{"all"}, "select rules to be applied")
+	rootCmd.PersistentFlags().String(logLevelFlagName, "info", "log level (trace, debug, info, warn, error, fatal)")
 
 	rootCmd.PersistentPreRun = preRun
 	rootCmd.PersistentPostRun = postRun
 
+	group := "Plugins"
+	rootCmd.AddGroup(&cobra.Group{Title: group, ID: group})
+
 	for _, plugin := range allPlugins {
 		subCommand, err := plugin.DefineCommand(channels)
+		subCommand.GroupID = group
 		if err != nil {
 			log.Fatal().Msg(fmt.Sprintf("error while defining command for plugin %s: %s", plugin.GetName(), err.Error()))
 		}
@@ -103,7 +112,7 @@ func validateTags(tags []string) {
 }
 
 func preRun(cmd *cobra.Command, args []string) {
-	tags, err := cmd.Flags().GetStringSlice("tags")
+	tags, err := cmd.Flags().GetStringSlice(tagsFlagName)
 	if err != nil {
 		log.Fatal().Msg(err.Error())
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -80,7 +80,7 @@ func Execute() {
 	rootCmd.PersistentPreRun = preRun
 	rootCmd.PersistentPostRun = postRun
 
-	group := "Plugins"
+	group := "Commands"
 	rootCmd.AddGroup(&cobra.Group{Title: group, ID: group})
 
 	for _, plugin := range allPlugins {

--- a/plugins/confluence.go
+++ b/plugins/confluence.go
@@ -41,16 +41,17 @@ func (p *ConfluencePlugin) GetCredentials() (string, string) {
 
 func (p *ConfluencePlugin) DefineCommand(channels Channels) (*cobra.Command, error) {
 	var confluenceCmd = &cobra.Command{
-		Use:   p.GetName(),
-		Short: "Scan confluence",
+		Use:   fmt.Sprintf("%s --%s URL", p.GetName(), argUrl),
+		Short: "Scan Confluence server",
+		Long:  "Scan Confluence server for sensitive information",
 	}
 
 	flags := confluenceCmd.Flags()
-	flags.StringP(argUrl, "", "", "confluence url")
-	flags.StringArray(argSpaces, []string{}, "confluence spaces")
-	flags.StringP(argUsername, "", "", "confluence username or email")
-	flags.StringP(argToken, "", "", "confluence token")
-	flags.BoolP(argHistory, "", false, "scan pages history")
+	flags.String(argUrl, "", "Confluence server URL (example: https://company.atlassian.net/wiki) [required]")
+	flags.StringArray(argSpaces, []string{}, "Confluence spaces: The names or IDs of the spaces to scan")
+	flags.String(argUsername, "", "Confluence user name or email for authentication")
+	flags.String(argToken, "", "The Confluence API token for authentication")
+	flags.Bool(argHistory, false, "Scan pages history")
 	err := confluenceCmd.MarkFlagRequired(argUrl)
 	if err != nil {
 		return nil, fmt.Errorf("error while marking '%s' flag as required: %w", argUrl, err)

--- a/plugins/confluence.go
+++ b/plugins/confluence.go
@@ -57,19 +57,19 @@ func (p *ConfluencePlugin) DefineCommand(channels Channels) (*cobra.Command, err
 	}
 
 	confluenceCmd.Run = func(cmd *cobra.Command, args []string) {
-		err := p.Initialize(cmd)
+		err := p.initialize(cmd)
 		if err != nil {
 			channels.Errors <- fmt.Errorf("error while initializing confluence plugin: %w", err)
 			return
 		}
 
-		p.GetItems(channels.Items, channels.Errors, channels.WaitGroup)
+		p.getItems(channels.Items, channels.Errors, channels.WaitGroup)
 	}
 
 	return confluenceCmd, nil
 }
 
-func (p *ConfluencePlugin) Initialize(cmd *cobra.Command) error {
+func (p *ConfluencePlugin) initialize(cmd *cobra.Command) error {
 	flags := cmd.Flags()
 	url, err := flags.GetString(argUrl)
 	if err != nil {
@@ -96,7 +96,7 @@ func (p *ConfluencePlugin) Initialize(cmd *cobra.Command) error {
 	return nil
 }
 
-func (p *ConfluencePlugin) GetItems(items chan Item, errs chan error, wg *sync.WaitGroup) {
+func (p *ConfluencePlugin) getItems(items chan Item, errs chan error, wg *sync.WaitGroup) {
 	p.getSpacesItems(items, errs, wg)
 }
 

--- a/plugins/discord.go
+++ b/plugins/discord.go
@@ -22,7 +22,6 @@ const (
 const defaultDateFrom = time.Hour * 24 * 14
 
 type DiscordPlugin struct {
-	Enabled          bool
 	Token            string
 	Guilds           []string
 	Channels         []string
@@ -62,19 +61,19 @@ func (p *DiscordPlugin) DefineCommand(channels Channels) (*cobra.Command, error)
 	}
 
 	discordCmd.Run = func(cmd *cobra.Command, args []string) {
-		err := p.Initialize(cmd)
+		err := p.initialize(cmd)
 		if err != nil {
 			channels.Errors <- fmt.Errorf("discord plugin initialization failed: %w", err)
 			return
 		}
 
-		p.GetItems(channels.Items, channels.Errors, channels.WaitGroup)
+		p.getItems(channels.Items, channels.Errors, channels.WaitGroup)
 	}
 
 	return discordCmd, nil
 }
 
-func (p *DiscordPlugin) Initialize(cmd *cobra.Command) error {
+func (p *DiscordPlugin) initialize(cmd *cobra.Command) error {
 	flags := cmd.Flags()
 	token, _ := flags.GetString(tokenFlag)
 	if token == "" {
@@ -102,16 +101,11 @@ func (p *DiscordPlugin) Initialize(cmd *cobra.Command) error {
 	p.Channels = channels
 	p.Count = count
 	p.BackwardDuration = fromDate
-	p.Enabled = true
 
 	return nil
 }
 
-func (p *DiscordPlugin) IsEnabled() bool {
-	return p.Enabled
-}
-
-func (p *DiscordPlugin) GetItems(itemsChan chan Item, errChan chan error, wg *sync.WaitGroup) {
+func (p *DiscordPlugin) getItems(itemsChan chan Item, errChan chan error, wg *sync.WaitGroup) {
 	defer wg.Done()
 
 	p.errChan = errChan

--- a/plugins/discord.go
+++ b/plugins/discord.go
@@ -40,25 +40,25 @@ func (p *DiscordPlugin) GetName() string {
 
 func (p *DiscordPlugin) DefineCommand(channels Channels) (*cobra.Command, error) {
 	var discordCmd = &cobra.Command{
-		Use:   p.GetName(),
-		Short: "Scan discord",
+		Use:   fmt.Sprintf("%s --%s TOKEN --%s SERVER", p.GetName(), tokenFlag, serversFlag),
+		Short: "Scan Discord server",
+		Long:  "Scan Discord server for sensitive information.",
 	}
 	flags := discordCmd.Flags()
 
-	flags.String(tokenFlag, "", "discord token")
-	flags.StringArray(serversFlag, []string{}, "discord servers")
-	flags.StringArray(channelsFlag, []string{}, "discord channels")
-	flags.Duration(fromDateFlag, defaultDateFrom, "discord from date")
-	flags.Int(messagesCountFlag, 0, "discord messages count")
-
+	flags.String(tokenFlag, "", "Discord token [required]")
 	err := discordCmd.MarkFlagRequired(tokenFlag)
 	if err != nil {
 		return nil, fmt.Errorf("error while marking '%s' flag as required: %w", tokenFlag, err)
 	}
+	flags.StringArray(serversFlag, []string{}, "Discord servers IDs to scan [required]")
 	err = discordCmd.MarkFlagRequired(serversFlag)
 	if err != nil {
 		return nil, fmt.Errorf("error while marking '%s' flag as required: %w", serversFlag, err)
 	}
+	flags.StringArray(channelsFlag, []string{}, "Discord channels IDs to scan. If not provided, all channels will be scanned")
+	flags.Duration(fromDateFlag, defaultDateFrom, "The time interval to scan from the current time. For example, 24h for 24 hours or 7d for 7 days.")
+	flags.Int(messagesCountFlag, 0, "The number of messages to scan. If not provided, all messages will be scanned until the fromDate flag value.")
 
 	discordCmd.Run = func(cmd *cobra.Command, args []string) {
 		err := p.initialize(cmd)

--- a/plugins/repository.go
+++ b/plugins/repository.go
@@ -23,12 +23,13 @@ func (p *RepositoryPlugin) GetName() string {
 
 func (p *RepositoryPlugin) DefineCommand(channels Channels) (*cobra.Command, error) {
 	var repositoryCmd = &cobra.Command{
-		Use:   p.GetName(),
-		Short: "Scan repository",
+		Use:   fmt.Sprintf("%s --%s PATH", p.GetName(), argRepository),
+		Short: "Scan local repository",
+		Long:  "Scan local repository for sensitive information",
 	}
 
 	flags := repositoryCmd.Flags()
-	flags.String(argRepository, "", "scan repository folder")
+	flags.String(argRepository, "", "Local repository path [required]")
 	err := repositoryCmd.MarkFlagRequired(argRepository)
 	if err != nil {
 		return nil, fmt.Errorf("error while marking '%s' flag as required: %w", argRepository, err)

--- a/plugins/repository.go
+++ b/plugins/repository.go
@@ -35,19 +35,20 @@ func (p *RepositoryPlugin) DefineCommand(channels Channels) (*cobra.Command, err
 	}
 
 	repositoryCmd.Run = func(cmd *cobra.Command, args []string) {
-		err := p.Initialize(cmd)
+		err := p.initialize(cmd)
 		if err != nil {
 			channels.Errors <- fmt.Errorf("error while initializing plugin: %w", err)
 			return
 		}
 
-		p.GetItems(channels.Items, channels.Errors, channels.WaitGroup)
+		channels.WaitGroup.Add(1)
+		go p.getFiles(channels.Items, channels.Errors, channels.WaitGroup)
 	}
 
 	return repositoryCmd, nil
 }
 
-func (p *RepositoryPlugin) Initialize(cmd *cobra.Command) error {
+func (p *RepositoryPlugin) initialize(cmd *cobra.Command) error {
 	flags := cmd.Flags()
 	directoryPath, err := flags.GetString(argRepository)
 	if err != nil {
@@ -56,13 +57,6 @@ func (p *RepositoryPlugin) Initialize(cmd *cobra.Command) error {
 
 	p.Path = directoryPath
 	return nil
-}
-
-func (p *RepositoryPlugin) GetItems(items chan Item, errs chan error, wg *sync.WaitGroup) {
-	defer wg.Done()
-
-	wg.Add(1)
-	go p.getFiles(items, errs, wg)
 }
 
 func (p *RepositoryPlugin) getFiles(items chan Item, errs chan error, wg *sync.WaitGroup) {


### PR DESCRIPTION
- make functions private
- add helpful examples for -h/--help/help

Close #43

```
❯ go run .
2ms Secrets Detection: A tool to detect secrets in public websites and communication services.

Usage:
  2ms [command]

Plugins
  confluence  Scan Confluence server
  discord     Scan Discord server
  repository  Scan local repository

Additional Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command

Flags:
  -h, --help               help for 2ms
      --log-level string   log level (trace, debug, info, warn, error, fatal) (default "info")
      --tags strings       select rules to be applied (default [all])
  -v, --version            version for 2ms

Use "2ms [command] --help" for more information about a command.
```

```
❯ go run . help confluence
Scan Confluence server for sensitive information

Usage:
  2ms confluence --url URL [flags]

Flags:
  -h, --help                 help for confluence
      --history              Scan pages history
      --spaces stringArray   Confluence spaces: The names or IDs of the spaces to scan
      --token string         The Confluence API token for authentication
      --url string           Confluence server URL (example: https://company.atlassian.net/wiki) [required]
      --username string      Confluence user name or email for authentication

Global Flags:
      --log-level string   log level (trace, debug, info, warn, error, fatal) (default "info")
      --tags strings       select rules to be applied (default [all])
```

```
❯ go run . help discord
Scan Discord server for sensitive information.

Usage:
  2ms discord --token TOKEN --server SERVER [flags]

Flags:
      --channel stringArray   Discord channels IDs to scan. If not provided, all channels will be scanned
      --duration duration     The time interval to scan from the current time. For example, 24h for 24 hours or 7d for 7 days. (default 336h0m0s)
  -h, --help                  help for discord
      --messages-count int    The number of messages to scan. If not provided, all messages will be scanned until the fromDate flag value.
      --server stringArray    Discord servers IDs to scan [required]
      --token string          Discord token [required]

Global Flags:
      --log-level string   log level (trace, debug, info, warn, error, fatal) (default "info")
      --tags strings       select rules to be applied (default [all])
```

```
❯ go run . help repository
Scan local repository for sensitive information

Usage:
  2ms repository --path PATH [flags]

Flags:
  -h, --help          help for repository
      --path string   Local repository path [required]

Global Flags:
      --log-level string   log level (trace, debug, info, warn, error, fatal) (default "info")
      --tags strings       select rules to be applied (default [all])
```
