### PR TITLE
Remove duplicated results & fix issue on query parameter

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -46,7 +46,7 @@ var channels = plugins.Channels{
 }
 
 var report = reporting.Init()
-var secretsChan = make(chan reporting.Secret)
+var secretsChan = make(chan secrets.Finding)
 
 func initLog() {
 	zerolog.SetGlobalLevel(zerolog.InfoLevel)
@@ -130,7 +130,7 @@ func preRun(cmd *cobra.Command, args []string) {
 				go secrets.Detect(secretsChan, item, channels.WaitGroup)
 			case secret := <-secretsChan:
 				report.TotalSecretsFound++
-				report.Results[secret.ID] = append(report.Results[secret.ID], secret)
+				report.AddSecret(secret)
 			case err, ok := <-channels.Errors:
 				if !ok {
 					return
@@ -147,7 +147,6 @@ func postRun(cmd *cobra.Command, args []string) {
 	// Wait for last secret to be added to report
 	time.Sleep(time.Millisecond * timeSleepInterval)
 
-	// -------------------------------------
 	// Show Report
 	if report.TotalItemsScanned > 0 {
 		report.ShowReport()

--- a/plugins/confluence.go
+++ b/plugins/confluence.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 
@@ -18,6 +19,7 @@ const (
 	argUsername             = "username"
 	argToken                = "token"
 	argHistory              = "history"
+	argPageId               = "pageId"
 	confluenceDefaultWindow = 25
 	confluenceMaxRequests   = 500
 )
@@ -251,20 +253,22 @@ func (p *ConfluencePlugin) getPageItems(items chan Item, errs chan error, wg *sy
 }
 
 func (p *ConfluencePlugin) getItem(page ConfluencePage, space ConfluenceSpaceResult, version int) (*Item, int, error) {
-	var url string
-	var originalUrl string
+	var itemUrl, originalUrl, id string
 
 	// If no version given get the latest, else get the specified version
 	if version == 0 {
-		url = fmt.Sprintf("%s/rest/api/content/%s?expand=body.storage.value,version,history.previousVersion", p.URL, page.ID)
+		itemUrl = fmt.Sprintf("%s/rest/api/content/%s?expand=body.storage.value,version,history.previousVersion", p.URL, page.ID)
 		originalUrl = fmt.Sprintf("%s/spaces/%s/pages/%s", p.URL, space.Key, page.ID)
-
+		aux := strings.Split(originalUrl, "/")
+		id = aux[len(aux)-1]
 	} else {
-		url = fmt.Sprintf("%s/rest/api/content/%s?status=historical&version=%d&expand=body.storage.value,version,history.previousVersion", p.URL, page.ID, version)
-		originalUrl = fmt.Sprintf("%s/pages/viewpage.action?pageid=%spageVersion=%d", p.URL, page.ID, version)
+		itemUrl = fmt.Sprintf("%s/rest/api/content/%s?status=historical&version=%d&expand=body.storage.value,version,history.previousVersion", p.URL, page.ID, version)
+		originalUrl = fmt.Sprintf("%s/pages/viewpage.action?pageId=%s&pageVersion=%d", p.URL, page.ID, version)
+		u, _ := url.Parse(originalUrl)
+		id = u.Query().Get(argPageId)
 	}
 
-	request, err := lib.HttpRequest(http.MethodGet, url, p)
+	request, err := lib.HttpRequest(http.MethodGet, itemUrl, p)
 	if err != nil {
 		return nil, 0, fmt.Errorf("unexpected error creating an http request %w", err)
 	}
@@ -276,8 +280,8 @@ func (p *ConfluencePlugin) getItem(page ConfluencePage, space ConfluenceSpaceRes
 
 	content := &Item{
 		Content: pageContent.Body.Storage.Value,
-		Source:  url,
-		ID:      originalUrl,
+		Source:  itemUrl,
+		ID:      id,
 	}
 	return content, pageContent.History.PreviousVersion.Number, nil
 }

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -2,7 +2,6 @@ package secrets
 
 import (
 	"github.com/checkmarx/2ms/plugins"
-	"github.com/checkmarx/2ms/reporting"
 	"github.com/zricethezav/gitleaks/v8/cmd/generate/config/rules"
 	"github.com/zricethezav/gitleaks/v8/config"
 	"github.com/zricethezav/gitleaks/v8/detect"
@@ -19,26 +18,39 @@ type Rule struct {
 	Rule config.Rule
 	Tags []string
 }
+type Finding struct {
+	ID          string
+	Source      string
+	Content     string
+	Description string
+	StartLine   int
+	EndLine     int
+	StartColumn int
+	EndColumn   int
+	Secret      string
+}
 
-const TagApiKey = "api-key"
-const TagClientId = "client-id"
-const TagClientSecret = "client-secret"
-const TagSecretKey = "secret-key"
-const TagAccessKey = "access-key"
-const TagAccessId = "access-id"
-const TagApiToken = "api-token"
-const TagAccessToken = "access-token"
-const TagRefreshToken = "refresh-token"
-const TagPrivateKey = "private-key"
-const TagPublicKey = "public-key"
-const TagEncryptionKey = "encryption-key"
-const TagTriggerToken = "trigger-token"
-const TagRegistrationToken = "registration-token"
-const TagPassword = "password"
-const TagUploadToken = "upload-token"
-const TagPublicSecret = "public-secret"
-const TagSensitiveUrl = "sensitive-url"
-const TagWebhook = "webhook"
+const (
+	TagApiKey            = "api-key"
+	TagClientId          = "client-id"
+	TagClientSecret      = "client-secret"
+	TagSecretKey         = "secret-key"
+	TagAccessKey         = "access-key"
+	TagAccessId          = "access-id"
+	TagApiToken          = "api-token"
+	TagAccessToken       = "access-token"
+	TagRefreshToken      = "refresh-token"
+	TagPrivateKey        = "private-key"
+	TagPublicKey         = "public-key"
+	TagEncryptionKey     = "encryption-key"
+	TagTriggerToken      = "trigger-token"
+	TagRegistrationToken = "registration-token"
+	TagPassword          = "password"
+	TagUploadToken       = "upload-token"
+	TagPublicSecret      = "public-secret"
+	TagSensitiveUrl      = "sensitive-url"
+	TagWebhook           = "webhook"
+)
 
 func Init(tags []string) *Secrets {
 
@@ -57,14 +69,14 @@ func Init(tags []string) *Secrets {
 	}
 }
 
-func (s *Secrets) Detect(secretsChannel chan reporting.Secret, item plugins.Item, wg *sync.WaitGroup) {
+func (s *Secrets) Detect(secretsChannel chan Finding, item plugins.Item, wg *sync.WaitGroup) {
 	defer wg.Done()
 
 	fragment := detect.Fragment{
 		Raw: item.Content,
 	}
-	for _, value := range s.detector.Detect(fragment) {
-		secretsChannel <- reporting.Secret{ID: item.ID, Description: value.Description, StartLine: value.StartLine, StartColumn: value.StartColumn, EndLine: value.EndLine, EndColumn: value.EndColumn, Value: value.Secret}
+	for _, find := range s.detector.Detect(fragment) {
+		secretsChannel <- Finding{ID: item.ID, Source: item.Source, Content: item.Content, Description: find.Description, StartLine: find.StartLine, EndLine: find.EndLine, StartColumn: find.StartColumn, EndColumn: find.EndColumn, Secret: find.Secret}
 	}
 }
 


### PR DESCRIPTION
To make the app suitable to don't show duplicated results some structural changes were applied:

The secrets module will return a Find instead of returning a Secret. Depending on if the find already exists or not, the secret will be created.

Now we are mapping the items by the page ID instead of the entire original URL

Secrets now have an array of links for all item versions where the secret is present.

Also was made a fix on confluence plugin where query parameters creation was wrong