### PR TITLE
feat: accept base64 encoded credentials

### DIFF
--- a/plugins/confluence.go
+++ b/plugins/confluence.go
@@ -39,6 +39,10 @@ func (p *ConfluencePlugin) GetCredentials() (string, string) {
 	return p.Username, p.Token
 }
 
+func (p *ConfluencePlugin) GetAuthorizationHeader() string {
+	return lib.CreateBasicAuthCredentials(p)
+}
+
 func (p *ConfluencePlugin) DefineCommand(channels Channels) (*cobra.Command, error) {
 	var confluenceCmd = &cobra.Command{
 		Use:   fmt.Sprintf("%s --%s URL", p.GetName(), argUrl),


### PR DESCRIPTION
In Jenkins, I sew users hosting their credentials as a `username:token` base64 encoded secret, so I want to support it as an argument.
