### PR TITLE
feat: added ignore pattern matching for filesystem plugin

### DIFF
--- a/plugins/filesystem.go
+++ b/plugins/filesystem.go
@@ -66,9 +66,10 @@ func (p *FileSystemPlugin) getFiles(items chan Item, errs chan error, wg *sync.W
 			if err != nil {
 				return err
 			}
-			if fInfo.IsDir() && matched {
+			if matched && fInfo.IsDir() {
 				return filepath.SkipDir
-			} else if matched {
+			}
+			if matched {
 				return nil
 			}
 		}


### PR DESCRIPTION
I added the `--ignore` flag to let the user add patterns for files to be ignored. A user may supply multiple patterns using this form: `2ms filesystem --path path --ignore "*foo" --ignore "bar*"`

I did not add tests as I am unsure how you guys want to test the plugins, worth discussing how a plugin test should be written.

Awaiting your feedback, cheers.

Close #93