### PR TITLE
feat: custom regex rule

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -154,8 +154,10 @@ func preRun(cmd *cobra.Command, args []string) {
 		log.Fatal().Msg(err.Error())
 	}
 
-	if err := secrets.AddRegexRule(customRegex); err != nil {
-		log.Fatal().Msg(err.Error())
+	if customRegex != "" {
+		if err := secrets.AddRegexRule(customRegex); err != nil {
+			log.Fatal().Msg(err.Error())
+		}
 	}
 
 	go func() {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -92,7 +92,10 @@ func Execute() {
 	rootCmd.PersistentFlags().StringSliceVar(&tagsVar, tagsFlagName, []string{"all"}, "select rules to be applied")
 	rootCmd.PersistentFlags().StringVar(&logLevelVar, logLevelFlagName, "info", "log level (trace, debug, info, warn, error, fatal)")
 	rootCmd.PersistentFlags().StringSliceVar(&reportPathVar, reportPathFlagName, []string{}, "path to generate report files. The output format will be determined by the file extension (.json, .yaml, .sarif)")
-	rootCmd.MarkFlagFilename(reportPathFlagName, "json", "yaml", "yml", "sarif")
+	err := rootCmd.MarkFlagFilename(reportPathFlagName, "json", "yaml", "yml", "sarif")
+	if err != nil {
+		cobra.CheckErr(err)
+	}
 	rootCmd.PersistentFlags().StringVar(&stdoutFormatVar, stdoutFormatFlagName, "yaml", "stdout output format, available formats are: json, yaml, sarif")
 	rootCmd.PersistentFlags().StringArrayVar(&customRegexRuleVar, customRegexRuleFlagName, []string{}, "custom regexes to apply to the scan, must be valid Go regex")
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -28,11 +28,11 @@ const (
 	yamlFormat        = "yaml"
 	sarifFormat       = "sarif"
 
-	tagsFlagName     = "tags"
-	logLevelFlagName = "log-level"
-	reportPath       = "report-path"
-	stdoutFormat     = "stdout-format"
-	customRegexRule  = "regex"
+	tagsFlagName            = "tags"
+	logLevelFlagName        = "log-level"
+	reportPathFlagName      = "report-path"
+	stdoutFormatFlagName    = "stdout-format"
+	customRegexRuleFlagName = "regex"
 )
 
 var (
@@ -91,10 +91,10 @@ func Execute() {
 	cobra.OnInitialize(initLog)
 	rootCmd.PersistentFlags().StringSliceVar(&tagsVar, tagsFlagName, []string{"all"}, "select rules to be applied")
 	rootCmd.PersistentFlags().StringVar(&logLevelVar, logLevelFlagName, "info", "log level (trace, debug, info, warn, error, fatal)")
-	rootCmd.PersistentFlags().StringSliceVar(&reportPathVar, reportPath, []string{""}, "path to generate report files. The output format will be determined by the file extension (.json, .yaml, .sarif)")
-	rootCmd.MarkFlagFilename(reportPath, "json", "yaml", "yml", "sarif")
-	rootCmd.PersistentFlags().StringVar(&stdoutFormatVar, stdoutFormat, "yaml", "stdout output format, available formats are: json, yaml, sarif")
-	rootCmd.PersistentFlags().StringArrayVar(&customRegexRuleVar, customRegexRule, []string{}, "custom regexes to apply to the scan, must be valid Go regex")
+	rootCmd.PersistentFlags().StringSliceVar(&reportPathVar, reportPathFlagName, []string{}, "path to generate report files. The output format will be determined by the file extension (.json, .yaml, .sarif)")
+	rootCmd.MarkFlagFilename(reportPathFlagName, "json", "yaml", "yml", "sarif")
+	rootCmd.PersistentFlags().StringVar(&stdoutFormatVar, stdoutFormatFlagName, "yaml", "stdout output format, available formats are: json, yaml, sarif")
+	rootCmd.PersistentFlags().StringArrayVar(&customRegexRuleVar, customRegexRuleFlagName, []string{}, "custom regexes to apply to the scan, must be valid Go regex")
 
 	rootCmd.PersistentPreRun = preRun
 	rootCmd.PersistentPostRun = postRun
@@ -176,7 +176,7 @@ func preRun(cmd *cobra.Command, args []string) {
 func postRun(cmd *cobra.Command, args []string) {
 	channels.WaitGroup.Wait()
 
-	validateFormat(stdoutFormat, reportPathVar)
+	validateFormat(stdoutFormatVar, reportPathVar)
 
 	cfg := config.LoadConfig("2ms", Version)
 
@@ -186,8 +186,8 @@ func postRun(cmd *cobra.Command, args []string) {
 	// -------------------------------------
 	// Show Report
 	if report.TotalItemsScanned > 0 {
-		report.ShowReport(stdoutFormat, cfg)
-		if len(reportPath) > 0 {
+		report.ShowReport(stdoutFormatVar, cfg)
+		if len(reportPathFlagName) > 0 {
 			err := report.WriteFile(reportPathVar, cfg)
 			if err != nil {
 				log.Error().Msgf("Failed to create report file with error: %s", err)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -92,10 +92,6 @@ func Execute() {
 	rootCmd.PersistentFlags().StringSliceVar(&tagsVar, tagsFlagName, []string{"all"}, "select rules to be applied")
 	rootCmd.PersistentFlags().StringVar(&logLevelVar, logLevelFlagName, "info", "log level (trace, debug, info, warn, error, fatal)")
 	rootCmd.PersistentFlags().StringSliceVar(&reportPathVar, reportPathFlagName, []string{}, "path to generate report files. The output format will be determined by the file extension (.json, .yaml, .sarif)")
-	err := rootCmd.MarkFlagFilename(reportPathFlagName, "json", "yaml", "yml", "sarif")
-	if err != nil {
-		cobra.CheckErr(err)
-	}
 	rootCmd.PersistentFlags().StringVar(&stdoutFormatVar, stdoutFormatFlagName, "yaml", "stdout output format, available formats are: json, yaml, sarif")
 	rootCmd.PersistentFlags().StringArrayVar(&customRegexRuleVar, customRegexRuleFlagName, []string{}, "custom regexes to apply to the scan, must be valid Go regex")
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -31,6 +31,7 @@ const (
 	jsonFormat        = "json"
 	yamlFormat        = "yaml"
 	sarifFormat       = "sarif"
+	customRegexRule   = "regex"
 )
 
 var rootCmd = &cobra.Command{
@@ -88,6 +89,7 @@ func Execute() {
 	rootCmd.PersistentFlags().String(logLevelFlagName, "info", "log level (trace, debug, info, warn, error, fatal)")
 	rootCmd.PersistentFlags().StringSlice(reportPath, []string{""}, "path to generate report files. The output format will be determined by the file extension (.json, .yaml, .sarif)")
 	rootCmd.PersistentFlags().String(stdoutFormat, "yaml", "stdout output format, available formats are: json, yaml, sarif")
+	rootCmd.PersistentFlags().String(customRegexRule, "", "custom regex to apply to the scan, must be valid Go regex")
 
 	rootCmd.PersistentPreRun = preRun
 	rootCmd.PersistentPostRun = postRun
@@ -146,6 +148,15 @@ func preRun(cmd *cobra.Command, args []string) {
 	validateTags(tags)
 
 	secrets := secrets.Init(tags)
+
+	customRegex, err := cmd.Flags().GetString(customRegexRule)
+	if err != nil {
+		log.Fatal().Msg(err.Error())
+	}
+
+	if err := secrets.AddRegexRule(customRegex); err != nil {
+		log.Fatal().Msg(err.Error())
+	}
 
 	go func() {
 		for {

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 )
 
 func main() {
+	zerolog.SetGlobalLevel(zerolog.InfoLevel)
 	// send all logs to stdout
 	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: "15:04:05"})
 

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -1,14 +1,17 @@
 package secrets
 
 import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+
 	"github.com/checkmarx/2ms/plugins"
 	"github.com/checkmarx/2ms/reporting"
 	"github.com/zricethezav/gitleaks/v8/cmd/generate/config/rules"
 	"github.com/zricethezav/gitleaks/v8/config"
 	"github.com/zricethezav/gitleaks/v8/detect"
-	"path/filepath"
-	"strings"
-	"sync"
 )
 
 type Secrets struct {
@@ -41,6 +44,8 @@ const TagPublicSecret = "public-secret"
 const TagSensitiveUrl = "sensitive-url"
 const TagWebhook = "webhook"
 
+const CustomRuleId = "custom-regex"
+
 func Init(tags []string) *Secrets {
 
 	allRules, _ := loadAllRules()
@@ -68,6 +73,25 @@ func (s *Secrets) Detect(secretsChannel chan reporting.Secret, item plugins.Item
 		itemId := getItemId(item.ID)
 		secretsChannel <- reporting.Secret{ID: itemId, Source: item.ID, Description: value.Description, StartLine: value.StartLine, StartColumn: value.StartColumn, EndLine: value.EndLine, EndColumn: value.EndColumn, Value: value.Secret}
 	}
+}
+
+func (s *Secrets) AddCustomRule(rule config.Rule) {
+	s.rules[rule.RuleID] = rule
+}
+
+func (s *Secrets) AddRegexRule(pattern string) error {
+	regex, err := regexp.Compile(pattern)
+	if err != nil {
+		return fmt.Errorf("failed to compile regex rule %s: %w", pattern, err)
+	}
+	rule := config.Rule{
+		Description: "Custom Regex Rule From User",
+		RuleID:      CustomRuleId,
+		Regex:       regex,
+		Keywords:    []string{},
+	}
+	s.AddCustomRule(rule)
+	return nil
 }
 
 func getItemId(fullPath string) string {

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -75,10 +75,6 @@ func (s *Secrets) Detect(secretsChannel chan reporting.Secret, item plugins.Item
 	}
 }
 
-func (s *Secrets) AddCustomRule(rule config.Rule) {
-	s.rules[rule.RuleID] = rule
-}
-
 func (s *Secrets) AddRegexRules(patterns []string) error {
 	for idx, pattern := range patterns {
 		regex, err := regexp.Compile(pattern)
@@ -91,7 +87,7 @@ func (s *Secrets) AddRegexRules(patterns []string) error {
 			Regex:       regex,
 			Keywords:    []string{},
 		}
-		s.AddCustomRule(rule)
+		s.rules[rule.RuleID] = rule
 	}
 	return nil
 }

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -44,7 +44,7 @@ const TagPublicSecret = "public-secret"
 const TagSensitiveUrl = "sensitive-url"
 const TagWebhook = "webhook"
 
-const CustomRuleId = "custom-regex"
+const customRegexRuleIdFormat = "custom-regex-%d"
 
 func Init(tags []string) *Secrets {
 
@@ -79,18 +79,20 @@ func (s *Secrets) AddCustomRule(rule config.Rule) {
 	s.rules[rule.RuleID] = rule
 }
 
-func (s *Secrets) AddRegexRule(pattern string) error {
-	regex, err := regexp.Compile(pattern)
-	if err != nil {
-		return fmt.Errorf("failed to compile regex rule %s: %w", pattern, err)
+func (s *Secrets) AddRegexRules(patterns []string) error {
+	for idx, pattern := range patterns {
+		regex, err := regexp.Compile(pattern)
+		if err != nil {
+			return fmt.Errorf("failed to compile regex rule %s: %w", pattern, err)
+		}
+		rule := config.Rule{
+			Description: "Custom Regex Rule From User",
+			RuleID:      fmt.Sprintf(customRegexRuleIdFormat, idx+1),
+			Regex:       regex,
+			Keywords:    []string{},
+		}
+		s.AddCustomRule(rule)
 	}
-	rule := config.Rule{
-		Description: "Custom Regex Rule From User",
-		RuleID:      CustomRuleId,
-		Regex:       regex,
-		Keywords:    []string{},
-	}
-	s.AddCustomRule(rule)
 	return nil
 }
 


### PR DESCRIPTION
<!-- 
Thanks for contributing to 2ms by offering a pull request.
Please add a "community" tag if you're an external contributor.
-->

Closes #98 

**Proposed Changes**
- Add a `--regex` flag on the main command to let the user supply a custom regex rule

I tested this with the filesystem plugin, but did not try with other plugins, would love if someone could test

I submit this contribution under the Apache-2.0 license.
