### PR TITLE
chore: accept also arguments splitted by comma

### DIFF
--- a/plugins/confluence.go
+++ b/plugins/confluence.go
@@ -51,11 +51,11 @@ func (p *ConfluencePlugin) DefineCommand(channels Channels) (*cobra.Command, err
 	}
 
 	flags := confluenceCmd.Flags()
-	flags.String(argUrl, "", "Confluence server URL (example: https://company.atlassian.net/wiki) [required]")
-	flags.StringArray(argSpaces, []string{}, "Confluence spaces: The names or IDs of the spaces to scan")
-	flags.String(argUsername, "", "Confluence user name or email for authentication")
-	flags.String(argToken, "", "The Confluence API token for authentication")
-	flags.Bool(argHistory, false, "Scan pages history")
+	flags.StringVar(&p.URL, argUrl, "", "Confluence server URL (example: https://company.atlassian.net/wiki) [required]")
+	flags.StringSliceVar(&p.Spaces, argSpaces, []string{}, "Confluence spaces: The names or IDs of the spaces to scan")
+	flags.StringVar(&p.Username, argUsername, "", "Confluence user name or email for authentication")
+	flags.StringVar(&p.Token, argToken, "", "The Confluence API token for authentication")
+	flags.BoolVar(&p.History, argHistory, false, "Scan pages history")
 	err := confluenceCmd.MarkFlagRequired(argUrl)
 	if err != nil {
 		return nil, fmt.Errorf("error while marking '%s' flag as required: %w", argUrl, err)
@@ -75,28 +75,13 @@ func (p *ConfluencePlugin) DefineCommand(channels Channels) (*cobra.Command, err
 }
 
 func (p *ConfluencePlugin) initialize(cmd *cobra.Command) error {
-	flags := cmd.Flags()
-	url, err := flags.GetString(argUrl)
-	if err != nil {
-		return fmt.Errorf("error while getting '%s' flag value: %w", argUrl, err)
-	}
 
-	url = strings.TrimRight(url, "/")
+	p.URL = strings.TrimRight(p.URL, "/")
 
-	spaces, _ := flags.GetStringArray(argSpaces)
-	username, _ := flags.GetString(argUsername)
-	token, _ := flags.GetString(argToken)
-	runHistory, _ := flags.GetBool(argHistory)
-
-	if username == "" || token == "" {
+	if p.Username == "" || p.Token == "" {
 		log.Warn().Msg("confluence credentials were not provided. The scan will be made anonymously only for the public pages")
 	}
 
-	p.Token = token
-	p.Username = username
-	p.URL = url
-	p.Spaces = spaces
-	p.History = runHistory
 	p.Limit = make(chan struct{}, confluenceMaxRequests)
 	return nil
 }

--- a/plugins/filesystem.go
+++ b/plugins/filesystem.go
@@ -18,7 +18,7 @@ var ignoredFolders = []string{".git"}
 type FileSystemPlugin struct {
 	Plugin
 	Path    string
-	Ignored *[]string
+	Ignored []string
 }
 
 func (p *FileSystemPlugin) GetName() string {
@@ -45,7 +45,7 @@ func (p *FileSystemPlugin) DefineCommand(channels Channels) (*cobra.Command, err
 		return nil, fmt.Errorf("error while marking '%s' flag as required: %w", flagFolder, err)
 	}
 
-	p.Ignored = flags.StringArray(flagIgnored, []string{}, "Patterns to ignore")
+	flags.StringSliceVar(&p.Ignored, flagIgnored, []string{}, "Patterns to ignore")
 
 	return cmd, nil
 }
@@ -61,7 +61,7 @@ func (p *FileSystemPlugin) getFiles(items chan Item, errs chan error, wg *sync.W
 				return filepath.SkipDir
 			}
 		}
-		for _, ignoredPattern := range *p.Ignored {
+		for _, ignoredPattern := range p.Ignored {
 			matched, err := filepath.Match(ignoredPattern, filepath.Base(path))
 			if err != nil {
 				return err

--- a/plugins/slack.go
+++ b/plugins/slack.go
@@ -60,7 +60,7 @@ func (p *SlackPlugin) DefineCommand(channels Channels) (*cobra.Command, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error while marking flag %s as required: %w", slackTeamFlag, err)
 	}
-	command.Flags().StringArrayVar(&channelsArg, slackChannelFlag, []string{}, "Slack channels to scan")
+	command.Flags().StringSliceVar(&channelsArg, slackChannelFlag, []string{}, "Slack channels to scan")
 	command.Flags().DurationVar(&backwardDurationArg, slackBackwardDurationFlag, slackDefaultDateFrom, "Slack backward duration for messages (ex: 24h, 7d, 1M, 1y)")
 	command.Flags().IntVar(&messagesCountArg, slackMessagesCountFlag, 0, "Slack messages count to scan (0 = all messages)")
 


### PR DESCRIPTION
Replaced:
> `StringArray`: The value of each argument will **not** try to be separated by comma. Use a `StringSlice` for that.

With:
> `StringSlice`: Compared to `StringArray` flags, `StringSlice` flags take comma-separated value as arguments and split them accordingly. For example:
> 
> `--ss="v1,v2" --ss="v3"`
> will result in
> 
> `[]string{"v1", "v2", "v3"}`
