### PR TITLE
ci: auto mark pr from forks as community

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,5 @@
 <!-- 
 Thanks for contributing to 2ms by offering a pull request.
-Please add a "community" tag if you're an external contributor.
 -->
 
 Closes #

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -1,0 +1,23 @@
+name: PR Labels
+
+on:
+  pull_request_target:
+    types: [opened]
+    
+jobs:
+  mark_as_community:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Mark as Community if PR is from a fork
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['Community']
+            })


### PR DESCRIPTION
<!-- 
Thanks for contributing to 2ms by offering a pull request.
Please add a "community" tag if you're an external contributor.
-->

Closes #101

**Proposed Changes**
- created the job in pr-labels.yml
- updated the guidelines in pull_request_template.md


I submit this contribution under the Apache-2.0 license.
