### PR TITLE
ci: notify on good first issue

### DIFF
--- a/.github/workflows/good-first-issue.yml
+++ b/.github/workflows/good-first-issue.yml
@@ -1,0 +1,19 @@
+name: Notify good-first-issue
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  notify_discrod:
+    name: Notify Discord
+    runs-on: ubuntu-latest
+    if: github.event.label.name == 'good first issue'
+    steps:
+      - name: Notify Discord
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_MAAKAF_WEBHOOK }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+        run: |
+          curl -X POST -H "Content-Type: application/json" -d "{\"embeds\": [{\"title\": \"🎉 New Issue Alert!\", \"description\": \"📢 Attention new contributors! This issue has been labeled as a 'good first issue'.\n\nIssue Name: **$ISSUE_TITLE**\nIssue Link: $ISSUE_URL\", \"color\": 16750848}]}" $DISCORD_WEBHOOK


### PR DESCRIPTION
This workflow will be triggered for each label on an issue, and if it is a `good first issue` label, it will send a message to Discord to invite contributors.

Close #104