### PR TITLE
feat: option to load arguments from config file

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -21,16 +21,16 @@ jobs:
         with:
           go-version: "^1.20"
 
+      - name: go mod tidy
+        run: |
+          go mod tidy
+          git diff --exit-code
+
       - name: Go Linter
         run: docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:v1.52.0 golangci-lint run -v -E gofmt --timeout=5m
 
       - name: Go Test
         run: go test -v ./...
-
-      - name: go mod tidy
-        run: |
-          go mod tidy
-          git diff --exit-code
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,6 @@ on:
   push:
     branches: [master]
 
-permissions:
-  contents: write
-
 jobs:
   test:
     name: Test
@@ -29,29 +26,6 @@ jobs:
 
       - name: Unit Tests
         run: go test ./...
-
-      - name: update README
-        run: |
-          help_message=$(go run .)
-          echo '```' > output.txt
-          echo "$help_message" >> output.txt
-          echo '```' >> output.txt
-          sed -i '/<!-- command-line:start -->/,/<!-- command-line:end -->/{
-            /<!-- command-line:start -->/{
-              p
-              r output.txt
-            }
-            /<!-- command-line:end -->/!d
-          }' README.md
-      - name: commit and push
-        id: git-check
-        continue-on-error: true
-        run: |
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git config --global user.name "github-actions[bot]"
-          git add README.md
-          git diff-index --quiet HEAD || git commit -m "docs: update help message in README.md"
-          git push
 
       - name: Gets release info
         id: semantic_release_info

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [master]
 
+permissions:
+  contents: write
+
 jobs:
   test:
     name: Test
@@ -26,6 +29,29 @@ jobs:
 
       - name: Unit Tests
         run: go test ./...
+
+      - name: update README
+        run: |
+          help_message=$(go run .)
+          echo '```' > output.txt
+          echo "$help_message" >> output.txt
+          echo '```' >> output.txt
+          sed -i '/<!-- command-line:start -->/,/<!-- command-line:end -->/{
+            /<!-- command-line:start -->/{
+              p
+              r output.txt
+            }
+            /<!-- command-line:end -->/!d
+          }' README.md
+      - name: commit and push
+        id: git-check
+        continue-on-error: true
+        run: |
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git add README.md
+          git diff-index --quiet HEAD || git commit -m "docs: update help message in README.md"
+          git push
 
       - name: Gets release info
         id: semantic_release_info

--- a/README.md
+++ b/README.md
@@ -37,8 +37,6 @@ docker run -v path/to/my/repo:/repo checkmarx/2ms git /repo
 
 <!-- command-line:start -->
 
-bla bla bla
-
 ```
 2ms Secrets Detection: A tool to detect secrets in public websites and communication services.
 
@@ -68,12 +66,48 @@ Flags:
   -v, --version                version for 2ms
 
 Use "2ms [command] --help" for more information about a command.
-bla bla bla
 ```
 
-bla bla bla
-
 <!-- command-line:end -->
+
+| :warning: Using configuration env or file                                                                                                                                                      |
+| :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Please note that even using configuration file or environment variables, you still need to specify the subcommand name in the CLI arguments. Also, positional arguments are not yet supported. |
+
+### Environment Variables
+
+To use a flag as an environment variable, see the following rules:
+
+- Replace `-` with `_`
+- Start with `2MS_`
+- Prefer uppercase
+- Append the subcommand name(s) (if any) with `_`
+
+Examples:
+
+- `--log-level` -> `2MS_LOG_LEVEL`
+- `paligo instance` -> `2MS_PALIGO_INSTANCE`
+
+### Configuration File
+
+You can use `--config` flag to specify a configuration file. The configuration file is a YAML/JSON file with the following structure:
+
+```yaml
+# global flags that will be applied to all commands
+log-level: info
+report-path:
+  - ./report.yaml
+  - ./report.json
+  - ./report.sarif
+
+# the subcommand will be selected from the CLI arguments
+# the flags below will be applied to the selected subcommand
+paligo:
+  instance: your-instance
+  username: your-username
+  # you can combine config file and Environment Variables
+  # token: your-token
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ During the software development lifecycle (SDLC), developers ofen communicate an
 - Git
 - Paligo
 - Local directory / files
-  
+
 ## Getting 2ms
 
 ```
@@ -35,12 +35,45 @@ docker run -v path/to/my/repo:/repo checkmarx/2ms git /repo
 
 ## Getting started
 
-### Command line arguments (wip, see [#20](https://github.com/Checkmarx/2ms/discussions/20))
+<!-- command-line:start -->
 
-- `--confluence` The URL of the Confluence instance to scan.
-- `--confluence-spaces` A comma-separated list of Confluence spaces to scan.
-- `--confluence-username` confluence username or email
-- `--confluence-token` confluence token
+bla bla bla
+
+```
+2ms Secrets Detection: A tool to detect secrets in public websites and communication services.
+
+Usage:
+  2ms [command]
+
+Commands
+  confluence  Scan Confluence server
+  discord     Scan Discord server
+  filesystem  Scan local folder
+  git         Scan Git repository
+  paligo      Scan Paligo instance
+  slack       Scan Slack team
+
+Additional Commands:
+  completion  Generate the autocompletion script for the specified shell
+  help        Help about any command
+
+Flags:
+      --config string          YAML config file path
+  -h, --help                   help for 2ms
+      --log-level string       log level (trace, debug, info, warn, error, fatal) (default "info")
+      --regex stringArray      custom regexes to apply to the scan, must be valid Go regex
+      --report-path strings    path to generate report files. The output format will be determined by the file extension (.json, .yaml, .sarif)
+      --stdout-format string   stdout output format, available formats are: json, yaml, sarif (default "yaml")
+      --tags strings           select rules to be applied (default [all])
+  -v, --version                version for 2ms
+
+Use "2ms [command] --help" for more information about a command.
+bla bla bla
+```
+
+bla bla bla
+
+<!-- command-line:end -->
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,6 @@ docker run -v path/to/my/repo:/repo checkmarx/2ms git /repo
 
 ## Getting started
 
-<!-- command-line:start -->
-
 ```
 2ms Secrets Detection: A tool to detect secrets in public websites and communication services.
 
@@ -68,8 +66,6 @@ Flags:
 
 Use "2ms [command] --help" for more information about a command.
 ```
-
-<!-- command-line:end -->
 
 | :warning: Using configuration env or file                                                                                                                                                      |
 | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -74,11 +74,7 @@ func initialize() {
 	if err != nil {
 		cobra.CheckErr(err)
 	}
-	if configFilePath != "" {
-		// TODO: Yaml? JSON?
-		vConfig.SetConfigFile(configFilePath)
-		cobra.CheckErr(vConfig.ReadInConfig())
-	}
+	cobra.CheckErr(lib.LoadConfig(vConfig, configFilePath))
 	cobra.CheckErr(lib.BindFlags(rootCmd, vConfig, envPrefix))
 
 	ll, err := rootCmd.Flags().GetString(logLevelFlagName)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -110,7 +110,8 @@ func Execute() {
 	vConfig.AutomaticEnv()
 
 	cobra.OnInitialize(initialize)
-	rootCmd.PersistentFlags().StringVar(&configFilePath, configFileFlag, "", "YAML config file path")
+	rootCmd.PersistentFlags().StringVar(&configFilePath, configFileFlag, "", "config file path")
+	cobra.CheckErr(rootCmd.MarkPersistentFlagFilename(configFileFlag, "yaml", "yml", "json"))
 	rootCmd.PersistentFlags().StringSliceVar(&tagsVar, tagsFlagName, []string{"all"}, "select rules to be applied")
 	rootCmd.PersistentFlags().StringVar(&logLevelVar, logLevelFlagName, "info", "log level (trace, debug, info, warn, error, fatal)")
 	rootCmd.PersistentFlags().StringSliceVar(&reportPathVar, reportPathFlagName, []string{}, "path to generate report files. The output format will be determined by the file extension (.json, .yaml, .sarif)")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -70,7 +70,7 @@ func initialize() {
 	zerolog.SetGlobalLevel(zerolog.InfoLevel)
 
 	// TODO: tests? check with the existing tests. combine levels of EnvVars, config and args
-	err := lib.LoadConfigFromFile(rootCmd, vConfig, configFileFlag, envPrefix)
+	err := lib.LoadConfigFromAllSources(rootCmd, vConfig, configFileFlag, envPrefix)
 	if err != nil {
 		cobra.CheckErr(err)
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -113,7 +113,6 @@ func Execute() {
 	cobra.OnInitialize(initialize)
 	rootCmd.PersistentFlags().StringVar(&configFilePath, configFileFlag, "", "config file path")
 	cobra.CheckErr(rootCmd.MarkPersistentFlagFilename(configFileFlag, "yaml", "yml", "json"))
-	rootCmd.PersistentFlags().StringSliceVar(&tagsVar, tagsFlagName, []string{"all"}, "select rules to be applied")
 	rootCmd.PersistentFlags().StringVar(&logLevelVar, logLevelFlagName, "info", "log level (trace, debug, info, warn, error, fatal)")
 	rootCmd.PersistentFlags().StringSliceVar(&reportPathVar, reportPathFlagName, []string{}, "path to generate report files. The output format will be determined by the file extension (.json, .yaml, .sarif)")
 	rootCmd.PersistentFlags().StringVar(&stdoutFormatVar, stdoutFormatFlagName, "yaml", "stdout output format, available formats are: json, yaml, sarif")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -66,14 +66,20 @@ var channels = plugins.Channels{
 var report = reporting.Init()
 var secretsChan = make(chan reporting.Secret)
 
+// TODO: docs
 func initialize() {
 	zerolog.SetGlobalLevel(zerolog.InfoLevel)
 
-	// TODO: tests? check with the existing tests. combine levels of EnvVars, config and args
-	err := lib.LoadConfigFromAllSources(rootCmd, vConfig, configFileFlag, envPrefix)
+	configFilePath, err := rootCmd.Flags().GetString(configFileFlag)
 	if err != nil {
 		cobra.CheckErr(err)
 	}
+	if configFilePath != "" {
+		// TODO: Yaml? JSON?
+		vConfig.SetConfigFile(configFilePath)
+		cobra.CheckErr(vConfig.ReadInConfig())
+	}
+	cobra.CheckErr(lib.BindFlags(rootCmd, vConfig, envPrefix))
 
 	ll, err := rootCmd.Flags().GetString(logLevelFlagName)
 	if err != nil {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -76,7 +76,6 @@ var channels = plugins.Channels{
 var report = reporting.Init()
 var secretsChan = make(chan reporting.Secret)
 
-// TODO: docs
 func initialize() {
 	zerolog.SetGlobalLevel(zerolog.InfoLevel)
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -111,7 +111,6 @@ func Execute() {
 
 	cobra.OnInitialize(initialize)
 	rootCmd.PersistentFlags().StringVar(&configFilePath, configFileFlag, "", "YAML config file path")
-	rootCmd.MarkFlagFilename(configFileFlag, "yaml", "yml")
 	rootCmd.PersistentFlags().StringSliceVar(&tagsVar, tagsFlagName, []string{"all"}, "select rules to be applied")
 	rootCmd.PersistentFlags().StringVar(&logLevelVar, logLevelFlagName, "info", "log level (trace, debug, info, warn, error, fatal)")
 	rootCmd.PersistentFlags().StringSliceVar(&reportPathVar, reportPathFlagName, []string{}, "path to generate report files. The output format will be determined by the file extension (.json, .yaml, .sarif)")

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,9 @@ require (
 	github.com/rs/zerolog v1.29.0
 	github.com/slack-go/slack v0.12.2
 	github.com/spf13/cobra v1.6.1
+	github.com/spf13/pflag v1.0.5
+	github.com/spf13/viper v1.15.0
+	github.com/stretchr/testify v1.8.1
 	github.com/zricethezav/gitleaks/v8 v8.16.1
 	golang.org/x/time v0.1.0
 	gopkg.in/yaml.v2 v2.4.0
@@ -16,6 +19,7 @@ require (
 require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/lipgloss v0.7.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/semgroup v1.2.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
@@ -33,12 +37,11 @@ require (
 	github.com/muesli/termenv v0.15.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.7 // indirect
 	github.com/petar-dambovaliev/aho-corasick v0.0.0-20211021192214-5ab2d9280aa9 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
 	github.com/spf13/afero v1.9.5 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/spf13/viper v1.15.0 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect
 	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa // indirect
 	golang.org/x/sync v0.1.0 // indirect

--- a/lib/flags.go
+++ b/lib/flags.go
@@ -16,12 +16,23 @@ func BindFlags(cmd *cobra.Command, v *viper.Viper, envPrefix string) error {
 	settingsMap := v.AllSettings()
 	cmd.PersistentFlags().VisitAll(func(f *pflag.Flag) {
 		settingsMap[f.Name] = true
-		if strings.Contains(f.Name, "-") {
-			envVarSuffix := strings.ToUpper(strings.ReplaceAll(f.Name, "-", "_"))
-			variableName := fmt.Sprintf("%s_%s", envPrefix, envVarSuffix)
-			if err := v.BindEnv(f.Name, variableName); err != nil {
-				log.Err(err).Msg("Failed to bind Viper flags")
-			}
+		envVarSuffix := strings.ToUpper(strings.ReplaceAll(f.Name, "-", "_"))
+		variableName := fmt.Sprintf("%s_%s", envPrefix, envVarSuffix)
+		if err := v.BindEnv(f.Name, variableName); err != nil {
+			log.Err(err).Msg("Failed to bind Viper flags")
+		}
+
+		if !f.Changed && v.IsSet(f.Name) {
+			val := v.Get(f.Name)
+			setBoundFlags(f, val, cmd)
+		}
+	})
+	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		settingsMap[f.Name] = true
+		envVarSuffix := strings.ToUpper(strings.ReplaceAll(f.Name, "-", "_"))
+		variableName := fmt.Sprintf("%s_%s", envPrefix, envVarSuffix)
+		if err := v.BindEnv(f.Name, variableName); err != nil {
+			log.Err(err).Msg("Failed to bind Viper flags")
 		}
 		if !f.Changed && v.IsSet(f.Name) {
 			val := v.Get(f.Name)

--- a/lib/flags.go
+++ b/lib/flags.go
@@ -10,26 +10,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-// TODO: remove cmd dependency
-func LoadConfigFromAllSources(rootCmd *cobra.Command, config *viper.Viper, configFileFlagName string, envPrefix string) error {
-	configFilePath, err := rootCmd.Flags().GetString(configFileFlagName)
-	if err != nil {
-		return err
-	}
-
-	if configFilePath != "" {
-		// TODO: Yaml? JSON?
-		config.SetConfigFile(configFilePath)
-		if err := config.ReadInConfig(); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 // TODO: can be a package
-// TODO: can be private now?
 // BindFlags fill flags values with config file or environment variables data
 func BindFlags(cmd *cobra.Command, v *viper.Viper, envPrefix string) error {
 	commandHierarchy := getCommandHierarchy(cmd)

--- a/lib/flags.go
+++ b/lib/flags.go
@@ -53,7 +53,6 @@ func bindEnvVarIntoViper(v *viper.Viper, fullFlagName, envPrefix string) {
 
 func applyViperFlagToCommand(flag *pflag.Flag, val interface{}, cmd *cobra.Command) {
 	switch t := val.(type) {
-	// TODO: remove this case?
 	case []interface{}:
 		var paramSlice []string
 		for _, param := range t {

--- a/lib/flags.go
+++ b/lib/flags.go
@@ -2,6 +2,7 @@ package lib
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/rs/zerolog/log"
@@ -9,6 +10,18 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
+
+func LoadConfig(v *viper.Viper, configFilePath string) error {
+	if configFilePath == "" {
+		return nil
+	}
+
+	configType := strings.TrimPrefix(filepath.Ext(configFilePath), ".")
+
+	v.SetConfigType(configType)
+	v.SetConfigFile(configFilePath)
+	return v.ReadInConfig()
+}
 
 // TODO: can be a package
 // BindFlags fill flags values with config file or environment variables data
@@ -28,7 +41,6 @@ func BindFlags(cmd *cobra.Command, v *viper.Viper, envPrefix string) error {
 			applyViperFlagToCommand(f, val, cmd)
 		}
 	}
-	// TODO: remove persistent flags
 	cmd.PersistentFlags().VisitAll(bindFlag)
 	cmd.Flags().VisitAll(bindFlag)
 

--- a/lib/flags.go
+++ b/lib/flags.go
@@ -24,6 +24,7 @@ func LoadConfig(v *viper.Viper, configFilePath string) error {
 }
 
 // TODO: can be a package
+
 // BindFlags fill flags values with config file or environment variables data
 func BindFlags(cmd *cobra.Command, v *viper.Viper, envPrefix string) error {
 	commandHierarchy := getCommandHierarchy(cmd)

--- a/lib/flags.go
+++ b/lib/flags.go
@@ -1,0 +1,56 @@
+package lib
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+)
+
+// BindFlags fill flags values with config file or environment variables data
+func BindFlags(cmd *cobra.Command, v *viper.Viper, envPrefix string) error {
+	log.Debug().Msg("console.bindFlags()")
+	settingsMap := v.AllSettings()
+	cmd.PersistentFlags().VisitAll(func(f *pflag.Flag) {
+		settingsMap[f.Name] = true
+		if strings.Contains(f.Name, "-") {
+			envVarSuffix := strings.ToUpper(strings.ReplaceAll(f.Name, "-", "_"))
+			variableName := fmt.Sprintf("%s_%s", envPrefix, envVarSuffix)
+			if err := v.BindEnv(f.Name, variableName); err != nil {
+				log.Err(err).Msg("Failed to bind Viper flags")
+			}
+		}
+		if !f.Changed && v.IsSet(f.Name) {
+			val := v.Get(f.Name)
+			setBoundFlags(f.Name, val, cmd)
+		}
+	})
+	for key, val := range settingsMap {
+		if val != true {
+			return fmt.Errorf("unknown configuration key: '%s'\nShowing help for '%s' command", key, cmd.Name())
+		}
+	}
+	return nil
+}
+
+func setBoundFlags(flagName string, val interface{}, cmd *cobra.Command) {
+	switch t := val.(type) {
+	case []interface{}:
+		var paramSlice []string
+		for _, param := range t {
+			paramSlice = append(paramSlice, param.(string))
+		}
+		valStr := strings.Join(paramSlice, ",")
+		if err := cmd.Flags().Set(flagName, valStr); err != nil {
+			log.Err(err).Msg("Failed to set Viper flags")
+		}
+	default:
+		newVal := fmt.Sprintf("%v", val)
+		if err := cmd.PersistentFlags().Set(flagName, newVal); err != nil {
+			log.Err(err).Msg("Failed to set Viper flags")
+		}
+	}
+}

--- a/lib/flags.go
+++ b/lib/flags.go
@@ -25,7 +25,7 @@ func BindFlags(cmd *cobra.Command, v *viper.Viper, envPrefix string) error {
 		}
 		if !f.Changed && v.IsSet(f.Name) {
 			val := v.Get(f.Name)
-			setBoundFlags(f.Name, val, cmd)
+			setBoundFlags(f, val, cmd)
 		}
 	})
 	for key, val := range settingsMap {
@@ -36,7 +36,7 @@ func BindFlags(cmd *cobra.Command, v *viper.Viper, envPrefix string) error {
 	return nil
 }
 
-func setBoundFlags(flagName string, val interface{}, cmd *cobra.Command) {
+func setBoundFlags(flag *pflag.Flag, val interface{}, cmd *cobra.Command) {
 	switch t := val.(type) {
 	case []interface{}:
 		var paramSlice []string
@@ -44,12 +44,12 @@ func setBoundFlags(flagName string, val interface{}, cmd *cobra.Command) {
 			paramSlice = append(paramSlice, param.(string))
 		}
 		valStr := strings.Join(paramSlice, ",")
-		if err := cmd.Flags().Set(flagName, valStr); err != nil {
+		if err := flag.Value.Set(valStr); err != nil {
 			log.Err(err).Msg("Failed to set Viper flags")
 		}
 	default:
 		newVal := fmt.Sprintf("%v", val)
-		if err := cmd.PersistentFlags().Set(flagName, newVal); err != nil {
+		if err := flag.Value.Set(newVal); err != nil {
 			log.Err(err).Msg("Failed to set Viper flags")
 		}
 	}

--- a/lib/flags.go
+++ b/lib/flags.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/viper"
 )
 
+// TODO: can be a package
 // BindFlags fill flags values with config file or environment variables data
 func BindFlags(cmd *cobra.Command, v *viper.Viper, envPrefix string) error {
 	settingsMap := v.AllSettings()
@@ -39,7 +40,7 @@ func bindEnvVarIntoViper(f *pflag.Flag, v *viper.Viper, envPrefix string) {
 	envVarSuffix := strings.ToUpper(strings.ReplaceAll(f.Name, "-", "_"))
 	envVarName := fmt.Sprintf("%s_%s", envPrefix, envVarSuffix)
 
-	if err := v.BindEnv(f.Name, envVarName); err != nil {
+	if err := v.BindEnv(f.Name, envVarName, strings.ToLower(envVarName)); err != nil {
 		log.Err(err).Msg("Failed to bind Viper flags")
 	}
 }

--- a/lib/flags.go
+++ b/lib/flags.go
@@ -10,7 +10,8 @@ import (
 	"github.com/spf13/viper"
 )
 
-func LoadConfigFromFile(rootCmd *cobra.Command, config *viper.Viper, configFileFlagName string, envPrefix string) error {
+// TODO: remove cmd dependency
+func LoadConfigFromAllSources(rootCmd *cobra.Command, config *viper.Viper, configFileFlagName string, envPrefix string) error {
 	configFilePath, err := rootCmd.Flags().GetString(configFileFlagName)
 	if err != nil {
 		return err

--- a/lib/flags.go
+++ b/lib/flags.go
@@ -33,6 +33,13 @@ func BindFlags(cmd *cobra.Command, v *viper.Viper, envPrefix string) error {
 			return fmt.Errorf("unknown configuration key: '%s'\nShowing help for '%s' command", key, cmd.Name())
 		}
 	}
+
+	for _, subCmd := range cmd.Commands() {
+		if err := BindFlags(subCmd, v, envPrefix); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/lib/flags_test.go
+++ b/lib/flags_test.go
@@ -13,8 +13,6 @@ import (
 )
 
 // TODO: positional arguments
-// TODO: assert.Equal to the expected value and not to viper value because I don't care about the viper key and value.
-// TODO: replace expected with actual
 
 const envVarPrefix = "PREFIX"
 
@@ -41,10 +39,10 @@ func TestBindFlags(t *testing.T) {
 		err := lib.BindFlags(cmd, v, envVarPrefix)
 		assert.NoError(t, err)
 
-		assert.Equal(t, testString, v.GetString("test-string"))
-		assert.Equal(t, testInt, v.GetInt("test-int"))
-		assert.Equal(t, testBool, v.GetBool("test-bool"))
-		assert.Equal(t, testFloat64, v.GetFloat64("test-float64"))
+		assert.Empty(t, testString)
+		assert.Empty(t, testInt)
+		assert.Empty(t, testBool)
+		assert.Empty(t, testFloat64)
 	})
 
 	t.Run("BindFlags_FromEnvVarsToCobraCommand", func(t *testing.T) {
@@ -79,16 +77,10 @@ func TestBindFlags(t *testing.T) {
 		err = lib.BindFlags(cmd, v, envVarPrefix)
 		assert.NoError(t, err)
 
-		assert.NotEmpty(t, v.GetString("test-string"))
-		assert.NotEmpty(t, v.GetInt("test-int"))
-		assert.NotEmpty(t, v.GetBool("test-bool"))
-		assert.NotEmpty(t, v.GetFloat64("test-float64"))
-
-		assert.Equal(t, testString, v.GetString("test-string"))
-		assert.Equal(t, testInt, v.GetInt("test-int"))
-		assert.Equal(t, testBool, v.GetBool("test-bool"))
-		assert.Equal(t, testFloat64, v.GetFloat64("test-float64"))
-
+		assert.Equal(t, "test-string-value", testString)
+		assert.Equal(t, 456, testInt)
+		assert.Equal(t, true, testBool)
+		assert.Equal(t, 1.23, testFloat64)
 	})
 
 	t.Run("BindFlags_NonPersistentFlags", func(t *testing.T) {
@@ -110,8 +102,7 @@ func TestBindFlags(t *testing.T) {
 		err = lib.BindFlags(cmd, v, envVarPrefix)
 		assert.NoError(t, err)
 
-		assert.NotEmpty(t, v.GetString("test-string"))
-		assert.Equal(t, testString, v.GetString("test-string"))
+		assert.Equal(t, "test-string-value", testString)
 	})
 
 	t.Run("BindFlags_Subcommand", func(t *testing.T) {
@@ -123,7 +114,9 @@ func TestBindFlags(t *testing.T) {
 			testInt    int
 		)
 
-		subCommand := &cobra.Command{}
+		subCommand := &cobra.Command{
+			Use: "subCommand",
+		}
 		subCommand.Flags().StringVar(&testString, "test-string", "", "Test string flag")
 		subCommand.PersistentFlags().IntVar(&testInt, "test-int", 0, "Test int flag")
 
@@ -131,19 +124,16 @@ func TestBindFlags(t *testing.T) {
 		cmd.AddCommand(subCommand)
 		v := getViper()
 
-		err := setEnv("PREFIX_TEST_STRING", "test-string-value")
+		err := setEnv("PREFIX_SUBCOMMAND_TEST_STRING", "test-string-value")
 		assert.NoError(t, err)
-		err = setEnv("PREFIX_TEST_INT", "456")
+		err = setEnv("PREFIX_SUBCOMMAND_TEST_INT", "456")
 		assert.NoError(t, err)
 
 		err = lib.BindFlags(cmd, v, envVarPrefix)
 		assert.NoError(t, err)
 
-		assert.NotEmpty(t, v.GetString("test-string"))
-		assert.NotEmpty(t, v.GetInt("test-int"))
-
-		assert.Equal(t, testString, v.GetString("test-string"))
-		assert.Equal(t, testInt, v.GetInt("test-int"))
+		assert.Equal(t, "test-string-value", testString)
+		assert.Equal(t, 456, testInt)
 	})
 
 	t.Run("BindFlags_ArrayFlag", func(t *testing.T) {
@@ -171,11 +161,8 @@ func TestBindFlags(t *testing.T) {
 		err = lib.BindFlags(cmd, v, envVarPrefix)
 		assert.NoError(t, err)
 
-		// assert.NotEmpty(t, v.GetStringSlice("test-array-spaces"))
-		assert.NotEmpty(t, v.GetStringSlice("test-array-commas"))
-
 		// assert.Equal(t, testArraySpaces, arr)
-		assert.Equal(t, testArrayCommas, arr)
+		assert.Equal(t, arr, testArrayCommas)
 	})
 
 	t.Run("BindFlags_ReturnsErrorForUnknownConfigurationKeys", func(t *testing.T) {
@@ -218,8 +205,7 @@ func TestBindFlags(t *testing.T) {
 		err = lib.BindFlags(cmd, v, envVarPrefix)
 		assert.NoError(t, err)
 
-		assert.NotEmpty(t, v.GetString("test-string"))
-		assert.Equal(t, testString, v.GetString("test-string"))
+		assert.Equal(t, "test-string-value", testString)
 	})
 
 	t.Run("BindFlags_OneWordFlagName", func(t *testing.T) {
@@ -241,8 +227,7 @@ func TestBindFlags(t *testing.T) {
 		err = lib.BindFlags(cmd, v, envVarPrefix)
 		assert.NoError(t, err)
 
-		assert.NotEmpty(t, v.GetString("teststring"))
-		assert.Equal(t, testString, v.GetString("teststring"))
+		assert.Equal(t, "test-string-value", testString)
 	})
 
 	t.Run("BindFlags_SameFlagNameDifferentCmd", func(t *testing.T) {
@@ -381,17 +366,11 @@ test-float: 123.456
 		err := lib.BindFlags(cmd, v, envVarPrefix)
 		assert.NoError(t, err)
 
-		assert.NotEmpty(t, v.GetString("test-string"))
-		assert.NotEmpty(t, v.GetInt("test-int"))
-		assert.NotEmpty(t, v.GetBool("test-bool"))
-		assert.NotEmpty(t, v.GetStringSlice("test-array"))
-		assert.NotEmpty(t, v.GetFloat64("test-float"))
-
-		assert.Equal(t, testString, v.GetString("test-string"))
-		assert.Equal(t, testInt, v.GetInt("test-int"))
-		assert.Equal(t, testBool, v.GetBool("test-bool"))
-		assert.Equal(t, testArray, v.GetStringSlice("test-array"))
-		assert.Equal(t, testFloat, v.GetFloat64("test-float"))
+		assert.Equal(t, "test-string-value", testString)
+		assert.Equal(t, 123, testInt)
+		assert.Equal(t, true, testBool)
+		assert.Equal(t, []string{"test", "array", "flag"}, testArray)
+		assert.Equal(t, 123.456, testFloat)
 	})
 
 	t.Run("BindFlags_FromYAML_SubCMD", func(t *testing.T) {
@@ -430,15 +409,10 @@ subCommand:
 		err := lib.BindFlags(cmd, v, envVarPrefix)
 		assert.NoError(t, err)
 
-		assert.NotEmpty(t, v.GetString("global-string"))
-		assert.NotEmpty(t, v.GetString("subCommand.test-string"))
-		assert.NotEmpty(t, v.GetInt("subCommand.test-int"))
-		assert.NotEmpty(t, v.GetBool("subCommand.test-bool"))
-
-		assert.Equal(t, globalString, v.GetString("global-string"))
-		assert.Equal(t, testString, v.GetString("subCommand.test-string"))
-		assert.Equal(t, testInt, v.GetInt("subCommand.test-int"))
-		assert.Equal(t, testBool, v.GetBool("subCommand.test-bool"))
+		assert.Equal(t, "global-string-value", globalString)
+		assert.Equal(t, "test-string-value", testString)
+		assert.Equal(t, 123, testInt)
+		assert.Equal(t, true, testBool)
 	})
 
 	t.Run("BindFlags_FromYAML_SubCMD_WithEnvVars", func(t *testing.T) {
@@ -481,10 +455,10 @@ subCommand:
 		err = lib.BindFlags(cmd, v, envVarPrefix)
 		assert.NoError(t, err)
 
-		assert.Equal(t, globalString, "global-string-value-from-env")
-		assert.Equal(t, testString, "test-string-value-from-env")
-		assert.Equal(t, testInt, 123)
-		assert.Equal(t, testBool, true)
+		assert.Equal(t, "global-string-value-from-env", globalString)
+		assert.Equal(t, "test-string-value-from-env", testString)
+		assert.Equal(t, 123, testInt)
+		assert.Equal(t, true, testBool)
 	})
 
 	t.Run("BindFlags_FromYAML_SubSubCmd", func(t *testing.T) {

--- a/lib/flags_test.go
+++ b/lib/flags_test.go
@@ -711,7 +711,7 @@ subcommand:
 			}
 			testString := cmd.PersistentFlags().String("test-string", "", "Test string flag")
 			testInt := cmd.PersistentFlags().Int("test-int", 0, "Test int flag")
-			assert.NoError(t, cmd.MarkFlagRequired("test-string"))
+			assert.NoError(t, cmd.MarkPersistentFlagRequired("test-string"))
 			cmd.PersistentFlags().String(configFlagName, "", "Config file name")
 
 			var subcommandBool bool

--- a/lib/flags_test.go
+++ b/lib/flags_test.go
@@ -1,6 +1,7 @@
 package lib_test
 
 import (
+	"bytes"
 	"os"
 	"strings"
 	"testing"
@@ -12,7 +13,8 @@ import (
 )
 
 // TODO: positional arguments
-// TODO: other resources
+// TODO: other resources (yaml)
+// TODO: sub of sub commands
 
 const envVarPrefix = "PREFIX"
 
@@ -177,6 +179,7 @@ func TestBindFlags(t *testing.T) {
 	})
 
 	t.Run("BindFlags_ReturnsErrorForUnknownConfigurationKeys", func(t *testing.T) {
+		t.Skip("Not sure if we need this feature.")
 		assertClearEnv(t)
 		defer clearEnvVars(t)
 
@@ -240,6 +243,157 @@ func TestBindFlags(t *testing.T) {
 
 		assert.NotEmpty(t, v.GetString("teststring"))
 		assert.Equal(t, testString, v.GetString("teststring"))
+	})
+
+	t.Run("BindFlags_FromYAML_RootCMD", func(t *testing.T) {
+		assertClearEnv(t)
+		defer clearEnvVars(t)
+
+		yamlConfig := []byte(`
+test-string: test-string-value
+test-int: 123
+test-bool: true
+test-array:
+  - test
+  - array
+  - flag
+test-float: 123.456
+`)
+
+		cmd := &cobra.Command{}
+		v := getViper()
+		v.SetConfigType("yaml")
+		v.ReadConfig(bytes.NewBuffer(yamlConfig))
+
+		var (
+			testString string
+			testInt    int
+			testBool   bool
+			testArray  []string
+			testFloat  float64
+		)
+
+		cmd.PersistentFlags().StringVar(&testString, "test-string", "", "Test string flag")
+		cmd.Flags().IntVar(&testInt, "test-int", 0, "Test int flag")
+		cmd.PersistentFlags().BoolVar(&testBool, "test-bool", false, "Test bool flag")
+		cmd.Flags().StringSliceVar(&testArray, "test-array", []string{}, "Test array flag")
+		cmd.PersistentFlags().Float64Var(&testFloat, "test-float", 0, "Test float flag")
+
+		err := lib.BindFlags(cmd, v, envVarPrefix)
+		assert.NoError(t, err)
+
+		assert.NotEmpty(t, v.GetString("test-string"))
+		assert.NotEmpty(t, v.GetInt("test-int"))
+		assert.NotEmpty(t, v.GetBool("test-bool"))
+		assert.NotEmpty(t, v.GetStringSlice("test-array"))
+		assert.NotEmpty(t, v.GetFloat64("test-float"))
+
+		assert.Equal(t, testString, v.GetString("test-string"))
+		assert.Equal(t, testInt, v.GetInt("test-int"))
+		assert.Equal(t, testBool, v.GetBool("test-bool"))
+		assert.Equal(t, testArray, v.GetStringSlice("test-array"))
+		assert.Equal(t, testFloat, v.GetFloat64("test-float"))
+	})
+
+	t.Run("BindFlags_FromYAML_SubCMD", func(t *testing.T) {
+		assertClearEnv(t)
+		defer clearEnvVars(t)
+
+		yamlConfig := []byte(`
+global-string: global-string-value
+subCommand:
+  test-string: test-string-value
+  test-int: 123
+  test-bool: true
+`)
+
+		cmd := &cobra.Command{}
+		v := getViper()
+		v.SetConfigType("yaml")
+		v.ReadConfig(bytes.NewBuffer(yamlConfig))
+
+		var (
+			globalString string
+			testString   string
+			testInt      int
+			testBool     bool
+		)
+
+		cmd.PersistentFlags().StringVar(&globalString, "global-string", "", "Global string flag")
+		subCmd := &cobra.Command{
+			Use: "subCommand",
+		}
+		cmd.AddCommand(subCmd)
+		subCmd.PersistentFlags().StringVar(&testString, "test-string", "", "Test string flag")
+		subCmd.Flags().IntVar(&testInt, "test-int", 0, "Test int flag")
+		subCmd.PersistentFlags().BoolVar(&testBool, "test-bool", false, "Test bool flag")
+
+		err := lib.BindFlags(cmd, v, envVarPrefix)
+		assert.NoError(t, err)
+
+		assert.NotEmpty(t, v.GetString("global-string"))
+		assert.NotEmpty(t, v.GetString("subCommand.test-string"))
+		assert.NotEmpty(t, v.GetInt("subCommand.test-int"))
+		assert.NotEmpty(t, v.GetBool("subCommand.test-bool"))
+
+		assert.Equal(t, globalString, v.GetString("global-string"))
+		assert.Equal(t, testString, v.GetString("subCommand.test-string"))
+		assert.Equal(t, testInt, v.GetInt("subCommand.test-int"))
+		assert.Equal(t, testBool, v.GetBool("subCommand.test-bool"))
+	})
+
+	t.Run("BindFlags_FromYAML_SubCMD_WithEnvVars", func(t *testing.T) {
+		assertClearEnv(t)
+		defer clearEnvVars(t)
+
+		yamlConfig := []byte(`
+global-string: global-string-value
+subCommand:
+  test-string: test-string-value
+  test-int: 123
+  test-bool: true
+`)
+		cmd := &cobra.Command{}
+		v := getViper()
+		v.SetConfigType("yaml")
+		v.ReadConfig(bytes.NewBuffer(yamlConfig))
+
+		var (
+			globalString string
+			testString   string
+			testInt      int
+			testBool     bool
+		)
+
+		cmd.PersistentFlags().StringVar(&globalString, "global-string", "", "Global string flag")
+		subCmd := &cobra.Command{
+			Use: "subCommand",
+		}
+		cmd.AddCommand(subCmd)
+		subCmd.PersistentFlags().StringVar(&testString, "test-string", "", "Test string flag")
+		subCmd.Flags().IntVar(&testInt, "test-int", 0, "Test int flag")
+		subCmd.PersistentFlags().BoolVar(&testBool, "test-bool", false, "Test bool flag")
+
+		err := setEnv("GLOBAL_STRING", "global-string-value-from-env")
+		assert.NoError(t, err)
+		err = setEnv("SUBCOMMAND_TEST_STRING", "test-string-value-from-env")
+		assert.NoError(t, err)
+
+		err = lib.BindFlags(cmd, v, envVarPrefix)
+		assert.NoError(t, err)
+
+		assert.Equal(t, "global-string-value-from-env", v.GetString("global-string"))
+		assert.Equal(t, "test-string-value-from-env", v.GetString("test-string"))
+
+		assert.NotEmpty(t, v.GetString("global-string"))
+		assert.NotEmpty(t, v.GetString("test-string"))
+		assert.NotEmpty(t, v.GetInt("test-int"))
+		assert.NotEmpty(t, v.GetBool("test-bool"))
+
+		assert.Equal(t, globalString, v.GetString("global-string"))
+		assert.Equal(t, testString, v.GetString("test-string"))
+		assert.Equal(t, testInt, v.GetInt("test-int"))
+		assert.Equal(t, testBool, v.GetBool("test-bool"))
 	})
 }
 

--- a/lib/flags_test.go
+++ b/lib/flags_test.go
@@ -15,6 +15,8 @@ import (
 // TODO: positional arguments
 // TODO: other resources (yaml)
 // TODO: sub of sub commands
+// TODO: same flag name in different commands level
+// TODO: assert.Equal to the expected value and not to viper value because I don't care about the viper key and value.
 
 const envVarPrefix = "PREFIX"
 
@@ -374,26 +376,18 @@ subCommand:
 		subCmd.Flags().IntVar(&testInt, "test-int", 0, "Test int flag")
 		subCmd.PersistentFlags().BoolVar(&testBool, "test-bool", false, "Test bool flag")
 
-		err := setEnv("GLOBAL_STRING", "global-string-value-from-env")
+		err := setEnv("PREFIX_GLOBAL_STRING", "global-string-value-from-env")
 		assert.NoError(t, err)
-		err = setEnv("SUBCOMMAND_TEST_STRING", "test-string-value-from-env")
+		err = setEnv("PREFIX_TEST_STRING", "test-string-value-from-env")
 		assert.NoError(t, err)
 
 		err = lib.BindFlags(cmd, v, envVarPrefix)
 		assert.NoError(t, err)
 
-		assert.Equal(t, "global-string-value-from-env", v.GetString("global-string"))
-		assert.Equal(t, "test-string-value-from-env", v.GetString("test-string"))
-
-		assert.NotEmpty(t, v.GetString("global-string"))
-		assert.NotEmpty(t, v.GetString("test-string"))
-		assert.NotEmpty(t, v.GetInt("test-int"))
-		assert.NotEmpty(t, v.GetBool("test-bool"))
-
-		assert.Equal(t, globalString, v.GetString("global-string"))
-		assert.Equal(t, testString, v.GetString("test-string"))
-		assert.Equal(t, testInt, v.GetInt("test-int"))
-		assert.Equal(t, testBool, v.GetBool("test-bool"))
+		assert.Equal(t, globalString, "global-string-value-from-env")
+		assert.Equal(t, testString, "test-string-value-from-env")
+		assert.Equal(t, testInt, 123)
+		assert.Equal(t, testBool, true)
 	})
 }
 

--- a/lib/flags_test.go
+++ b/lib/flags_test.go
@@ -349,7 +349,7 @@ test-float: 123.456
 		cmd := &cobra.Command{}
 		v := getViper()
 		v.SetConfigType("yaml")
-		v.ReadConfig(bytes.NewBuffer(yamlConfig))
+		assert.NoError(t, v.ReadConfig(bytes.NewBuffer(yamlConfig)))
 
 		var (
 			testString string
@@ -390,7 +390,7 @@ subCommand:
 		cmd := &cobra.Command{}
 		v := getViper()
 		v.SetConfigType("yaml")
-		v.ReadConfig(bytes.NewBuffer(yamlConfig))
+		assert.NoError(t, v.ReadConfig(bytes.NewBuffer(yamlConfig)))
 
 		var (
 			globalString string
@@ -431,7 +431,7 @@ subCommand:
 		cmd := &cobra.Command{}
 		v := getViper()
 		v.SetConfigType("yaml")
-		v.ReadConfig(bytes.NewBuffer(yamlConfig))
+		assert.NoError(t, v.ReadConfig(bytes.NewBuffer(yamlConfig)))
 
 		var (
 			globalString string
@@ -477,7 +477,7 @@ subCommand:
 		cmd := &cobra.Command{}
 		v := getViper()
 		v.SetConfigType("yaml")
-		v.ReadConfig(bytes.NewBuffer(yamlConfig))
+		assert.NoError(t, v.ReadConfig(bytes.NewBuffer(yamlConfig)))
 
 		var (
 			globalString string
@@ -518,7 +518,7 @@ subCommand:
 		cmd := &cobra.Command{}
 		v := getViper()
 		v.SetConfigType("yaml")
-		v.ReadConfig(bytes.NewBuffer(yamlConfig))
+		assert.NoError(t, v.ReadConfig(bytes.NewBuffer(yamlConfig)))
 
 		var (
 			testStringRoot string
@@ -553,7 +553,7 @@ subCommand:
 		cmd := &cobra.Command{}
 		v := getViper()
 		v.SetConfigType("yaml")
-		v.ReadConfig(bytes.NewBuffer(yamlConfig))
+		assert.NoError(t, v.ReadConfig(bytes.NewBuffer(yamlConfig)))
 
 		var (
 			testStringRoot string
@@ -591,7 +591,7 @@ subCommand:
 		cmd := &cobra.Command{}
 		v := getViper()
 		v.SetConfigType("json")
-		v.ReadConfig(bytes.NewBuffer(jsonConfig))
+		assert.NoError(t, v.ReadConfig(bytes.NewBuffer(jsonConfig)))
 
 		subCmd := &cobra.Command{
 			Use: "subCommand",
@@ -711,7 +711,7 @@ subcommand:
 			}
 			testString := cmd.PersistentFlags().String("test-string", "", "Test string flag")
 			testInt := cmd.PersistentFlags().Int("test-int", 0, "Test int flag")
-			cmd.MarkFlagRequired("test-string")
+			assert.NoError(t, cmd.MarkFlagRequired("test-string"))
 			cmd.PersistentFlags().String(configFlagName, "", "Config file name")
 
 			var subcommandBool bool

--- a/lib/flags_test.go
+++ b/lib/flags_test.go
@@ -1,0 +1,129 @@
+package lib_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/checkmarx/2ms/lib"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+// TODO: test subcommand
+// TODO: test array
+// TODO: test persistent and not persistent flags
+// TODO: lowercase and uppercase env vars
+// TODO: test unknown configuration flag (flag in viper but not in cobra)
+// TODO: positional arguments
+
+func TestBindFlags(t *testing.T) {
+	t.Run("BindFlags_TestEmptyViper", func(t *testing.T) {
+		cmd := &cobra.Command{}
+		v := viper.New()
+
+		var (
+			testString  string
+			testInt     int
+			testBool    bool
+			testFloat64 float64
+		)
+
+		cmd.PersistentFlags().StringVar(&testString, "test-string", "", "Test string flag")
+		cmd.PersistentFlags().IntVar(&testInt, "test-int", 0, "Test int flag")
+		cmd.PersistentFlags().BoolVar(&testBool, "test-bool", false, "Test bool flag")
+		cmd.PersistentFlags().Float64Var(&testFloat64, "test-float64", 0.0, "Test float64 flag")
+
+		err := lib.BindFlags(cmd, v, "PREFIX")
+		assert.NoError(t, err)
+
+		assert.Equal(t, testString, v.GetString("test-string"))
+		assert.Equal(t, testInt, v.GetInt("test-int"))
+		assert.Equal(t, testBool, v.GetBool("test-bool"))
+		assert.Equal(t, testFloat64, v.GetFloat64("test-float64"))
+	})
+
+	t.Run("BindFlags_FromEnvVarsToCobraCommand", func(t *testing.T) {
+		cmd := &cobra.Command{}
+		v := viper.New()
+		v.SetEnvPrefix("PREFIX")
+
+		var (
+			testString  string
+			testInt     int
+			testBool    bool
+			testFloat64 float64
+		)
+
+		cmd.PersistentFlags().StringVar(&testString, "test-string", "", "Test string flag")
+		cmd.PersistentFlags().IntVar(&testInt, "test-int", 0, "Test int flag")
+		cmd.PersistentFlags().BoolVar(&testBool, "test-bool", false, "Test bool flag")
+		cmd.PersistentFlags().Float64Var(&testFloat64, "test-float64", 0.0, "Test float64 flag")
+
+		err := setEnv("PREFIX_TEST_STRING", "test-string-value")
+		assert.NoError(t, err)
+		err = setEnv("PREFIX_TEST_INT", "456")
+		assert.NoError(t, err)
+		err = setEnv("PREFIX_TEST_BOOL", "true")
+		assert.NoError(t, err)
+		err = setEnv("PREFIX_TEST_FLOAT64", "1.23")
+		assert.NoError(t, err)
+
+		err = lib.BindFlags(cmd, v, "PREFIX")
+		assert.NoError(t, err)
+
+		assert.Equal(t, testString, v.GetString("test-string"))
+		assert.Equal(t, testInt, v.GetInt("test-int"))
+		assert.Equal(t, testBool, v.GetBool("test-bool"))
+		assert.Equal(t, testFloat64, v.GetFloat64("test-float64"))
+
+	})
+
+	t.Run("BindFlags_NonPersistentFlags", func(t *testing.T) {
+
+		cmd := &cobra.Command{}
+		v := viper.New()
+
+		var (
+			testString string
+		)
+
+		cmd.Flags().StringVar(&testString, "test-string", "", "Test string flag")
+
+		err := setEnv("PREFIX_TEST_STRING", "test-string-value")
+		assert.NoError(t, err)
+
+		err = lib.BindFlags(cmd, v, "PREFIX")
+		assert.NoError(t, err)
+
+		assert.Equal(t, testString, v.GetString("test-string"))
+	})
+
+	t.Run("BindFlags_ReturnsErrorForUnknownConfigurationKeys", func(t *testing.T) {
+		// Create a new Cobra command and Viper instance
+		cmd := &cobra.Command{}
+		v := viper.New()
+
+		// Define some test flags
+		var (
+			testString string
+		)
+
+		// Add the test flag to the command
+		cmd.PersistentFlags().StringVar(&testString, "test-string", "", "Test string flag")
+
+		// Set an unknown configuration key
+		v.Set("unknown-key", "unknown-value")
+
+		// Bind the flags to the Viper instance
+		err := lib.BindFlags(cmd, v, "PREFIX")
+
+		// Test that an error is returned for unknown configuration keys
+		assert.EqualError(t, err, "unknown configuration key: 'unknown-key'\nShowing help for '' command")
+	})
+}
+
+// Helper function to set an environment variable for testing
+func setEnv(key, value string) error {
+	return os.Setenv(key, value)
+}

--- a/lib/flags_test.go
+++ b/lib/flags_test.go
@@ -2,6 +2,7 @@ package lib_test
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/checkmarx/2ms/lib"
@@ -147,23 +148,32 @@ func TestBindFlags(t *testing.T) {
 		assertClearEnv(t)
 		defer clearEnvVars(t)
 
+		arr := []string{"test", "array", "flag"}
+
 		cmd := &cobra.Command{}
 		v := getViper()
 
 		var (
-			testArray []string
+			// testArraySpaces []string
+			testArrayCommas []string
 		)
 
-		cmd.PersistentFlags().StringSliceVar(&testArray, "test-array", []string{}, "Test array flag")
+		// cmd.PersistentFlags().StringSliceVar(&testArraySpaces, "test-array-spaces", []string{}, "Test array flag")
+		cmd.PersistentFlags().StringSliceVar(&testArrayCommas, "test-array-commas", []string{}, "Test array flag")
 
-		err := setEnv("PREFIX_TEST_ARRAY", "test,array,value")
+		// err := setEnv("PREFIX_TEST_ARRAY_SPACES", strings.Join(arr, " "))
+		// assert.NoError(t, err)
+		err := setEnv("PREFIX_TEST_ARRAY_COMMAS", strings.Join(arr, ","))
 		assert.NoError(t, err)
 
 		err = lib.BindFlags(cmd, v, envVarPrefix)
 		assert.NoError(t, err)
 
-		assert.NotEmpty(t, v.GetStringSlice("test-array"))
-		assert.Equal(t, testArray, v.GetStringSlice("test-array"))
+		// assert.NotEmpty(t, v.GetStringSlice("test-array-spaces"))
+		assert.NotEmpty(t, v.GetStringSlice("test-array-commas"))
+
+		// assert.Equal(t, testArraySpaces, arr)
+		assert.Equal(t, testArrayCommas, arr)
 	})
 
 	t.Run("BindFlags_ReturnsErrorForUnknownConfigurationKeys", func(t *testing.T) {

--- a/lib/flags_test.go
+++ b/lib/flags_test.go
@@ -229,49 +229,7 @@ func TestBindFlags(t *testing.T) {
 	})
 
 	t.Run("BindFlags_SameFlagNameDifferentCmd", func(t *testing.T) {
-		/*
-			When the same flag name is used in different commands, the last command
-			will overwrite the previous one.
-			var (
-				cmd1op1 string
-				cmd1op2 string
-				rootOp1 string
-				rootOp2 string
-			)
 
-			func Execute() {
-				var rootCmd = &cobra.Command{
-					Use: "",
-					Run: func(cmd *cobra.Command, args []string) {
-						log.Printf("cmd1op1: %s", cmd1op1)
-						log.Printf("cmd1op2: %s", cmd1op2)
-						log.Printf("rootOp1: %s", rootOp1)
-						log.Printf("rootOp2: %s", rootOp2)
-					},
-				}
-
-				cmd1 := &cobra.Command{
-					Use: "cmd1",
-					Run: func(cmd *cobra.Command, args []string) {
-						log.Printf("cmd1op1: %s", cmd1op1)
-						log.Printf("cmd1op2: %s", cmd1op2)
-						log.Printf("rootOp1: %s", rootOp1)
-						log.Printf("rootOp2: %s", rootOp2)
-					},
-				}
-				cmd1.PersistentFlags().StringVar(&cmd1op1, "op1", "", "persistent option1 for cmd1, not required for rootCmd")
-				cmd1.Flags().StringVar(&cmd1op2, "op2", "", "option2 for cmd1, not required for rootCmd")
-				rootCmd.AddCommand(cmd1)
-
-				rootCmd.PersistentFlags().StringVar(&rootOp1, "op1", "", "persistent option1 for rootCmd, not required for cmd1")
-				rootCmd.Flags().StringVar(&rootOp2, "op2", "", "option2 for rootCmd, not required for cmd1")
-
-				err := rootCmd.Execute()
-				if err != nil {
-					os.Exit(1)
-				}
-			}
-		*/
 		assertClearEnv(t)
 		defer clearEnvVars(t)
 

--- a/lib/flags_test.go
+++ b/lib/flags_test.go
@@ -631,7 +631,14 @@ subcommand:
 	var v *viper.Viper
 
 	cobra.OnInitialize(func() {
-		err := lib.LoadConfigFromAllSources(cmd, v, configFlagName, envVarPrefix)
+		configFilePath, err := cmd.Flags().GetString(configFlagName)
+		if err != nil {
+			cobra.CheckErr(err)
+		}
+		if configFilePath != "" {
+			v.SetConfigFile(configFilePath)
+			assert.NoError(t, v.ReadInConfig())
+		}
 		assert.NoError(t, err)
 		err = lib.BindFlags(cmd, v, envVarPrefix)
 		assert.NoError(t, err)

--- a/lib/flags_test.go
+++ b/lib/flags_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TODO: positional arguments
-
 const envVarPrefix = "PREFIX"
 
 func TestBindFlags(t *testing.T) {

--- a/lib/flags_test.go
+++ b/lib/flags_test.go
@@ -277,7 +277,9 @@ func TestBindFlags(t *testing.T) {
 		assertClearEnv(t)
 		defer clearEnvVars(t)
 
-		rootCmd := &cobra.Command{}
+		rootCmd := &cobra.Command{
+			Use: "root",
+		}
 		cmd1 := &cobra.Command{
 			Use: "cmd1",
 		}

--- a/lib/flags_test.go
+++ b/lib/flags_test.go
@@ -17,6 +17,9 @@ const envVarPrefix = "PREFIX"
 
 func TestBindFlags(t *testing.T) {
 	t.Run("BindFlags_TestEmptyViper", func(t *testing.T) {
+		assertClearEnv(t)
+		defer clearEnvVars(t)
+
 		cmd := &cobra.Command{}
 		v := getViper()
 
@@ -42,6 +45,9 @@ func TestBindFlags(t *testing.T) {
 	})
 
 	t.Run("BindFlags_FromEnvVarsToCobraCommand", func(t *testing.T) {
+		assertClearEnv(t)
+		defer clearEnvVars(t)
+
 		cmd := &cobra.Command{}
 		v := getViper()
 		v.SetEnvPrefix(envVarPrefix)
@@ -83,6 +89,9 @@ func TestBindFlags(t *testing.T) {
 	})
 
 	t.Run("BindFlags_NonPersistentFlags", func(t *testing.T) {
+		assertClearEnv(t)
+		defer clearEnvVars(t)
+
 		cmd := &cobra.Command{}
 		v := getViper()
 
@@ -103,6 +112,9 @@ func TestBindFlags(t *testing.T) {
 	})
 
 	t.Run("BindFlags_Subcommand", func(t *testing.T) {
+		assertClearEnv(t)
+		defer clearEnvVars(t)
+
 		var (
 			testString string
 			testInt    int
@@ -132,6 +144,9 @@ func TestBindFlags(t *testing.T) {
 	})
 
 	t.Run("BindFlags_ArrayFlag", func(t *testing.T) {
+		assertClearEnv(t)
+		defer clearEnvVars(t)
+
 		cmd := &cobra.Command{}
 		v := getViper()
 
@@ -152,6 +167,9 @@ func TestBindFlags(t *testing.T) {
 	})
 
 	t.Run("BindFlags_ReturnsErrorForUnknownConfigurationKeys", func(t *testing.T) {
+		assertClearEnv(t)
+		defer clearEnvVars(t)
+
 		cmd := &cobra.Command{}
 		v := getViper()
 
@@ -169,6 +187,9 @@ func TestBindFlags(t *testing.T) {
 	})
 
 	t.Run("BindFlags_LowerCaseEnvVars", func(t *testing.T) {
+		assertClearEnv(t)
+		defer clearEnvVars(t)
+
 		cmd := &cobra.Command{}
 		v := getViper()
 
@@ -189,6 +210,9 @@ func TestBindFlags(t *testing.T) {
 	})
 
 	t.Run("BindFlags_OneWordFlagName", func(t *testing.T) {
+		assertClearEnv(t)
+		defer clearEnvVars(t)
+
 		cmd := &cobra.Command{}
 		v := getViper()
 
@@ -209,10 +233,24 @@ func TestBindFlags(t *testing.T) {
 	})
 }
 
-// TODO: dont change the env vars!
-// Helper function to set an environment variable for testing
+var envKeys []string
+
+func assertClearEnv(t *testing.T) {
+	assert.Len(t, envKeys, 0)
+}
+
 func setEnv(key, value string) error {
+	envKeys = append(envKeys, key)
 	return os.Setenv(key, value)
+}
+
+func clearEnvVars(t *testing.T) {
+	for len(envKeys) > 0 {
+		key := envKeys[0]
+		err := os.Unsetenv(key)
+		assert.NoError(t, err)
+		envKeys = envKeys[1:]
+	}
 }
 
 func getViper() *viper.Viper {


### PR DESCRIPTION
- bind flags from viper to cobra command
- add tests
- test for Execute
- support multiple config formats
- update readme with help message
- document configuration env and file

Closes #21

**Proposed Changes**
- feat: read arguments from Environment Variables
- feat: read arguments from JSON/YAML file
- docs: auto-update the README when the `help` message was changed
- docs: how to use arguments from Environment Variables or config file

**Limitations**
- You still can run only one plugin at a time.
- You have to add the plugin command to the CLI command.
- Positional arguments are not yet supported.
