### PR TITLE
docs: user feedbacks about documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,12 @@ During the software development lifecycle (SDLC), developers ofen communicate an
 - Git
 - Paligo
 - Local directory / files
-  
+
 ## Getting 2ms
 
-```
-# go install github.com/checkmarx/2ms@latest
+```bash
+curl -LO https://github.com/Checkmarx/2ms/releases/latest/download/2ms && chmod +x 2ms
+./2ms
 ```
 
 ### Docker

--- a/plugins/git.go
+++ b/plugins/git.go
@@ -23,9 +23,9 @@ func (p *GitPlugin) DefineCommand(channels Channels) (*cobra.Command, error) {
 	p.Channels = channels
 
 	command := &cobra.Command{
-		Use:   fmt.Sprintf("%s <PATH>", p.GetName()),
-		Short: "Scan Git repository",
-		Long:  "Scan Git repository for sensitive information.",
+		Use:   fmt.Sprintf("%s <CLONED_REPO>", p.GetName()),
+		Short: "Scan local Git repository",
+		Long:  "Scan local Git repository for sensitive information.",
 		Args:  cobra.MatchAll(cobra.ExactArgs(1), validGitRepoArgs),
 		Run: func(cmd *cobra.Command, args []string) {
 			log.Info().Msg("Git plugin started")

--- a/plugins/paligo.go
+++ b/plugins/paligo.go
@@ -90,7 +90,7 @@ func (p *PaligoPlugin) DefineCommand(channels Channels) (*cobra.Command, error) 
 	command.MarkFlagsMutuallyExclusive(paligoUsernameFlag, paligoAuthFlag)
 	command.MarkFlagsMutuallyExclusive(paligoTokenFlag, paligoAuthFlag)
 
-	command.Flags().IntVar(&paligoFolderArg, paligoFolderFlag, 0, "Paligo folder ID")
+	command.Flags().IntVar(&paligoFolderArg, paligoFolderFlag, 0, "Paligo folder ID. If not specified, the whole instance will be scanned")
 
 	return command, nil
 }

--- a/plugins/paligo.go
+++ b/plugins/paligo.go
@@ -302,8 +302,11 @@ func (p *PaligoClient) listFolders() (*[]EmptyFolder, error) {
 
 	var folders *ListFoldersResponse
 	err = json.Unmarshal(body, &folders)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing folders response: %w", err)
+	}
 
-	return &folders.Folders, err
+	return &folders.Folders, nil
 }
 
 func (p *PaligoClient) showFolder(folderId int) (*Folder, error) {


### PR DESCRIPTION
- fix: describing message for wrong instance
- fix: If not giving folder, what will be scanned
- fix: Can I give a Github URL? Or clone the repo?
- docs: go install command installing an old version

Closes #111
