### PR TITLE
fix: SARIF output again

### DIFF
--- a/reporting/sarif.go
+++ b/reporting/sarif.go
@@ -64,9 +64,9 @@ func getResults(report Report) []Results {
 		for _, secret := range secrets {
 			r := Results{
 				Message: Message{
-					Text: messageText(secret.ID, secret.Source),
+					Text: messageText(secret.RuleID, secret.Source),
 				},
-				RuleId:    secret.ID,
+				RuleId:    secret.RuleID,
 				Locations: getLocation(secret),
 			}
 			results = append(results, r)


### PR DESCRIPTION
Now it is OK for sure and I will prove you:

**The output:**

```sarif
{
 "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
 "version": "2.1.0",
 "runs": [
  {
   "tool": {
    "driver": {
     "name": "2ms",
     "semanticVersion": "0.0.0"
    }
   },
   "results": [
    {
     "message": {
      "text": "private-key has detected secret for file reporting/report_test.go."
     },
     "ruleId": "private-key",
     "locations": [
      {
       "physicalLocation": {
        "artifactLocation": {
         "uri": "reporting/report_test.go"
        },
        "region": {
         "startLine": 9,
         "startColumn": 2,
         "endLine": 23,
         "endColumn": 29,
         "snippet": {
          "text": "-----BEGIN RSA PRIVATE KEY-----\nMIICWwIBAAKBgQCKLwIHewTIhcpH3WLnxZ61xBAk2lnkdahFxjHYi+khrENzbGr8\nEeJDZ1FMUDDYGeLtjlROLHT41ovicFbsmgIU0QQVFewIAwvKIw5hBtq0TtO9CsXe\nBaNmzw8ZduXJ/clOpdOF7/1ro485a+v956ZAhB2ohbk6qRqGyg3kaxclOQIDAQAB\nAoGAV7z5QN6vbtLkWTUMc7VazHas+Xla0mCSc5sgUyqi4CqMuWEBnQON8tZLHHVe\nThhBqixRA0HfE5DGSQSjbJ9s6fD+Sjt0Qj2yer70FuEiR0uGM4tOAE7WbX+Ny7PT\ngmDiWOITe7v0yzIgZzbLgPhg5SlCmiy8Nv2Zf/v54yLVPLECQQDbwpsuu6beMDip\nkRB/msCAEEAstdfSPY8L9QySYxskkJvtWpWBu5trnRatiGoLYWvnsBzcL4xWGrs8\nTpr4hTirAkEAoPiRDHrVbkKAgrmLW/TrSDiOG8uXSTuvz4iFgzCG6Cd8bp7mDKhJ\nl98Upelf0Is5sEnLDqnFl62LZAyckeThqwJAOjZChQ6QFSsQ11nl1OdZNpMXbMB+\neuJzkedHfT9jYTwtEaJ9F/BqKwdhinYoIPudabHs8yZlNim+jysDQfGIIQJAGqlx\nJPcHeO7M6FohKgcEHX84koQDN98J/L7pFlSoU7WOl6f8BKavIdeSTPS9qQYWdQuT\n9YbLMpdNGjI4kLWvZwJAJt8Qnbc2ZfS0ianwphoOdB0EwOMKNygjnYx7VoqR9/h1\n4Xgur9w/aLZrLM3DSatR+kL+cVTyDTtgCt9Dc8k48Q==\n-----END RSA PRIVATE KEY----"
         }
        }
       }
      }
     ]
    }
   ]
  }
 ]
}
```

**The Viewer:**
![image](https://github.com/Checkmarx/2ms/assets/17686879/4c782054-9321-4c40-9034-c94b1794b230)

**The code highlight!!**

![image](https://github.com/Checkmarx/2ms/assets/17686879/5d05511d-f95e-46fd-9412-922a6684d7b5)
