### PR TITLE
refactor: removes print of "Summary:" from console output

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -45,7 +45,7 @@ jobs:
       - run: make build
       - name: Run docker and check its output
         run:
-          if docker run -v "$(pwd)":/repo -t checkmarx/2ms:latest git /repo | grep -A 5 "Summary:"; then
+          if docker run -v "$(pwd)":/repo -t checkmarx/2ms:latest git /repo | grep -A 5 "totalitemsscanned:"; then
           echo "Docker ran as expected";
           else
           echo "Docker did not run as expected";

--- a/reporting/report.go
+++ b/reporting/report.go
@@ -40,8 +40,6 @@ func Init() *Report {
 
 func (r *Report) ShowReport(format string, cfg *config.Config) {
 	output := r.getOutput(format, cfg)
-
-	fmt.Println("Summary:")
 	fmt.Print(output)
 }
 


### PR DESCRIPTION
<!-- 
Thanks for contributing to 2ms by offering a pull request.
-->

**Proposed Changes**
- removes summary from console output

We take the output from 2ms and create a file with it, and we run a "validate sarif format" over it, and the console output has the "Summary:" on top of it all, so I'm suggesting removing it

I submit this contribution under the Apache-2.0 license.
