### PR TITLE
fix: split logs to stdout and stderr

### DIFF
--- a/lib/logger.go
+++ b/lib/logger.go
@@ -12,7 +12,7 @@ type SpecificLevelWriter struct {
 	Levels []zerolog.Level
 }
 
-func (w *SpecificLevelWriter) WriteLevel(level zerolog.Level, p []byte) (int, error) {
+func (w SpecificLevelWriter) WriteLevel(level zerolog.Level, p []byte) (int, error) {
 	for _, l := range w.Levels {
 		if l == level {
 			return w.Write(p)
@@ -23,13 +23,13 @@ func (w *SpecificLevelWriter) WriteLevel(level zerolog.Level, p []byte) (int, er
 
 func CreateLogger(minimumLevel zerolog.Level) zerolog.Logger {
 	writer := zerolog.MultiLevelWriter(
-		&SpecificLevelWriter{
+		SpecificLevelWriter{
 			Writer: zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: "15:04:05"},
 			Levels: []zerolog.Level{
 				zerolog.DebugLevel, zerolog.InfoLevel, zerolog.WarnLevel,
 			},
 		},
-		&SpecificLevelWriter{
+		SpecificLevelWriter{
 			Writer: zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: "15:04:05"},
 			Levels: []zerolog.Level{
 				zerolog.ErrorLevel, zerolog.FatalLevel, zerolog.PanicLevel,

--- a/lib/logger.go
+++ b/lib/logger.go
@@ -1,0 +1,41 @@
+package lib
+
+import (
+	"io"
+	"os"
+
+	"github.com/rs/zerolog"
+)
+
+type SpecificLevelWriter struct {
+	io.Writer
+	Levels []zerolog.Level
+}
+
+func (w *SpecificLevelWriter) WriteLevel(level zerolog.Level, p []byte) (int, error) {
+	for _, l := range w.Levels {
+		if l == level {
+			return w.Write(p)
+		}
+	}
+	return len(p), nil
+}
+
+func CreateLogger(minimumLevel zerolog.Level) zerolog.Logger {
+	writer := zerolog.MultiLevelWriter(
+		&SpecificLevelWriter{
+			Writer: zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: "15:04:05"},
+			Levels: []zerolog.Level{
+				zerolog.DebugLevel, zerolog.InfoLevel, zerolog.WarnLevel,
+			},
+		},
+		&SpecificLevelWriter{
+			Writer: zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: "15:04:05"},
+			Levels: []zerolog.Level{
+				zerolog.ErrorLevel, zerolog.FatalLevel, zerolog.PanicLevel,
+			},
+		},
+	)
+
+	return zerolog.New(writer).Level(minimumLevel).With().Timestamp().Logger()
+}

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"os/signal"
 
 	"github.com/checkmarx/2ms/cmd"
+	"github.com/checkmarx/2ms/lib"
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -12,8 +13,7 @@ import (
 
 func main() {
 	zerolog.SetGlobalLevel(zerolog.InfoLevel)
-	// send all logs to stdout
-	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: "15:04:05"})
+	log.Logger = lib.CreateLogger(zerolog.InfoLevel)
 
 	// this block sets up a go routine to listen for an interrupt signal
 	// which will immediately exit gitleaks


### PR DESCRIPTION
Fixes #156

References:
https://stackoverflow.com/questions/76858037/how-to-use-zerolog-to-filter-info-logs-to-stdout-and-error-logs-to-stderr
https://github.com/rs/zerolog/issues/150#issuecomment-1667749783
