### PR TITLE
fix: bad error message when scanning 2ms git for non-git dir

### DIFF
--- a/plugins/git.go
+++ b/plugins/git.go
@@ -101,7 +101,7 @@ func validGitRepoArgs(cmd *cobra.Command, args []string) error {
 	gitFolder := fmt.Sprintf("%s/.git", args[0])
 	stat, err = os.Stat(gitFolder)
 	if err != nil {
-		return err
+		return fmt.Errorf("Error - %s is not a git repository. Please make sure the root path of the provided directory contains .git subdirectory", args[0])
 	}
 	if !stat.IsDir() {
 		return fmt.Errorf("%s is not a git repository", args[0])

--- a/plugins/git.go
+++ b/plugins/git.go
@@ -101,7 +101,7 @@ func validGitRepoArgs(cmd *cobra.Command, args []string) error {
 	gitFolder := fmt.Sprintf("%s/.git", args[0])
 	stat, err = os.Stat(gitFolder)
 	if err != nil {
-		return fmt.Errorf("Error - %s is not a git repository. Please make sure the root path of the provided directory contains .git subdirectory", args[0])
+		return fmt.Errorf("%s is not a git repository. Please make sure the root path of the provided directory contains a .git subdirectory", args[0])
 	}
 	if !stat.IsDir() {
 		return fmt.Errorf("%s is not a git repository", args[0])


### PR DESCRIPTION
Closes #163 

**Proposed Changes**
- changed the default OS error message when running `2ms git` on non-git directories to match the suggested error message on issue 163.

I submit this contribution under the Apache-2.0 license.
