### PR TITLE
chore: remove time.sleep at the end of run

### DIFF
--- a/plugins/filesystem.go
+++ b/plugins/filesystem.go
@@ -29,14 +29,18 @@ func (p *FileSystemPlugin) GetName() string {
 	return "filesystem"
 }
 
-func (p *FileSystemPlugin) DefineCommand(channels Channels) (*cobra.Command, error) {
+func (p *FileSystemPlugin) DefineCommand(items chan Item, errors chan error) (*cobra.Command, error) {
 	var cmd = &cobra.Command{
 		Use:   fmt.Sprintf("%s --%s PATH", p.GetName(), flagFolder),
 		Short: "Scan local folder",
 		Long:  "Scan local folder for sensitive information",
 		Run: func(cmd *cobra.Command, args []string) {
 			log.Info().Msg("Folder plugin started")
-			p.getFiles(channels.Items, channels.Errors, channels.WaitGroup)
+
+			wg := &sync.WaitGroup{}
+			p.getFiles(items, errors, wg)
+			wg.Wait()
+			close(items)
 		},
 	}
 

--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -27,5 +27,5 @@ type Channels struct {
 
 type IPlugin interface {
 	GetName() string
-	DefineCommand(channels Channels) (*cobra.Command, error)
+	DefineCommand(items chan Item, errors chan error) (*cobra.Command, error)
 }


### PR DESCRIPTION
Fixes #59

First I notices we're not waiting for the `PreRun` routine that handles all the channels.

Then, to `Done` the routine that listen to the channel, I need to close the channel.
