### PR TITLE
fix: using --log-level has no effect

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -33,7 +33,7 @@ jobs:
         run: docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:v1.52.0 golangci-lint run -v -E gofmt --timeout=5m --out-format github-actions
 
       - name: Run 2ms Scan
-        run: go run . git . --config /repo/.2ms.yml
+        run: go run . git . --config .2ms.yml
 
       - name: Go Test
         run: go test -v ./...

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -81,8 +81,6 @@ var report = reporting.Init()
 var secretsChan = make(chan reporting.Secret)
 
 func initialize() {
-	zerolog.SetGlobalLevel(zerolog.InfoLevel)
-
 	configFilePath, err := rootCmd.Flags().GetString(configFileFlag)
 	if err != nil {
 		cobra.CheckErr(err)
@@ -90,22 +88,23 @@ func initialize() {
 	cobra.CheckErr(lib.LoadConfig(vConfig, configFilePath))
 	cobra.CheckErr(lib.BindFlags(rootCmd, vConfig, envPrefix))
 
+	logLevel := zerolog.InfoLevel
 	switch strings.ToLower(logLevelVar) {
 	case "trace":
-		zerolog.SetGlobalLevel(zerolog.TraceLevel)
+		logLevel = zerolog.TraceLevel
 	case "debug":
-		zerolog.SetGlobalLevel(zerolog.DebugLevel)
+		logLevel = zerolog.DebugLevel
 	case "info":
-		zerolog.SetGlobalLevel(zerolog.InfoLevel)
+		logLevel = zerolog.InfoLevel
 	case "warn":
-		zerolog.SetGlobalLevel(zerolog.WarnLevel)
+		logLevel = zerolog.WarnLevel
 	case "err", "error":
-		zerolog.SetGlobalLevel(zerolog.ErrorLevel)
+		logLevel = zerolog.ErrorLevel
 	case "fatal":
-		zerolog.SetGlobalLevel(zerolog.FatalLevel)
-	default:
-		zerolog.SetGlobalLevel(zerolog.InfoLevel)
+		logLevel = zerolog.FatalLevel
 	}
+	zerolog.SetGlobalLevel(logLevel)
+	log.Logger = log.Logger.Level(logLevel)
 }
 
 func Execute() {


### PR DESCRIPTION
Since I splitted the log to stdout and stderr, the `--log-level debug` has no effect because of the new log implementation.
