### PR TITLE
fix: report directory is not exist

### DIFF
--- a/reporting/report.go
+++ b/reporting/report.go
@@ -41,6 +41,11 @@ func (r *Report) ShowReport(format string, cfg *config.Config) error {
 
 func (r *Report) WriteFile(reportPath []string, cfg *config.Config) error {
 	for _, path := range reportPath {
+		err := os.MkdirAll(filepath.Dir(path), 0750)
+		if err != nil {
+			return err
+		}
+
 		file, err := os.Create(path)
 		if err != nil {
 			return err

--- a/reporting/report_test.go
+++ b/reporting/report_test.go
@@ -1,9 +1,12 @@
 package reporting
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
+	"github.com/checkmarx/2ms/config"
 	"github.com/checkmarx/2ms/secrets"
 )
 
@@ -40,4 +43,17 @@ JPcHeO7M6FohKgcEHX84koQDN98J/L7pFlSoU7WOl6f8BKavIdeSTPS9qQYWdQuT
 	if !reflect.DeepEqual(report.Results, results) {
 		t.Errorf("got %+v want %+v", key, results)
 	}
+}
+
+func TestWriteReportInNonExistingDir(t *testing.T) {
+	report := Init()
+
+	tempDir := os.TempDir()
+	path := filepath.Join(tempDir, "test_temp_dir", "sub_dir", "report.yaml")
+	err := report.WriteFile([]string{path}, &config.Config{Name: "report", Version: "5"})
+	if err != nil {
+		t.Error(err)
+	}
+
+	os.RemoveAll(filepath.Join(tempDir, "test_temp_dir"))
 }


### PR DESCRIPTION
Closes #200 

I would usually start a discussion about a change before starting, but since this was just a tiny fix I skipped it this time. Hope that's Ok.

This adds a path existence check to the path(s) passed in and ensures the directory exists.

I submit this contribution under the Apache-2.0 license.
