### PR TITLE
ci: use Weburz/pr-lint-action

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -5,14 +5,8 @@ on:
     types: [opened, edited, synchronize, reopened]
 
 jobs:
-  validate:
+  pr-lint:
+    name: Lint PR Titles
     runs-on: ubuntu-latest
     steps:
-      - name: install commitlint
-        run: npm install -g @commitlint/cli @commitlint/config-conventional
-      - name: config commitlint
-        run: |
-          echo "module.exports = {extends: ['@commitlint/config-conventional']}" > commitlint.config.js
-      - name: validate PR title
-        run: |
-          echo ${{ github.event.pull_request.title }} | commitlint
+      - uses: Weburz/pr-lint-action@ec1ad6afd2210cb4f73b28a369d579b9c263e888

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -9,4 +9,4 @@ jobs:
     name: Lint PR Titles
     runs-on: ubuntu-latest
     steps:
-      - uses: Weburz/pr-lint-action@ec1ad6afd2210cb4f73b28a369d579b9c263e888
+      - uses: Weburz/pr-lint-action@2ecff97b8e96423f024b159426f8ca78e3f00a77


### PR DESCRIPTION
This pull request updates the CI workflow to use the Weburz/pr-lint-action for linting PR titles. This action will help ensure that PR titles follow the conventional commit format.