### PR TITLE
test: add e2e confluence test

### DIFF
--- a/tests/e2e.go
+++ b/tests/e2e.go
@@ -54,8 +54,10 @@ func generateProject(outputDir string) error {
 	return nil
 }
 
-func (c *cli) run(projectDir string, args ...string) error {
-	argsWithDefault := append([]string{"filesystem", "--path", projectDir, "--report-path", c.resultsPath}, args...)
+func (c *cli) run(command string, args ...string) error {
+	argsWithDefault := append([]string{command}, args...)
+	argsWithDefault = append(argsWithDefault, "--report-path", c.resultsPath)
+
 	cmd := exec.Command(c.executable, argsWithDefault...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/tests/e2e.go
+++ b/tests/e2e.go
@@ -1,5 +1,7 @@
 package tests
 
+// TODO: add confluence test
+
 import (
 	"encoding/json"
 	"fmt"

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -2,7 +2,7 @@ package tests
 
 import "testing"
 
-func TestFilesystemIntegration(t *testing.T) {
+func TestIntegration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping e2e test")
 	}
@@ -12,15 +12,15 @@ func TestFilesystemIntegration(t *testing.T) {
 		t.Fatalf("failed to build CLI: %s", err)
 	}
 
-	projectDir := t.TempDir()
+	t.Run("filesystem: one secret found", func(t *testing.T) {
+		projectDir := t.TempDir()
 
-	t.Run("one secret found", func(t *testing.T) {
 		if err := generateProject(projectDir); err != nil {
 			t.Fatalf("failed to generate project: %s", err)
 		}
 
 		if err := executable.run("filesystem", "--path", projectDir); err == nil {
-			t.Error("expected error, got nil")
+			t.Error("expected error (secrets found), got nil")
 		}
 
 		report, err := executable.getReport()
@@ -30,6 +30,29 @@ func TestFilesystemIntegration(t *testing.T) {
 
 		if len(report.Results) != 1 {
 			t.Errorf("expected one result, got %d", len(report.Results))
+		}
+	})
+
+	t.Run("confluence: secrets found with validation", func(t *testing.T) {
+		if err := executable.run("confluence", "https://checkmarx.atlassian.net/wiki", "--spaces", "secrets", "--validate"); err == nil {
+			t.Error("expected error (secrets found), got nil")
+		}
+
+		report, err := executable.getReport()
+		if err != nil {
+			t.Fatalf("failed to get report: %s", err)
+		}
+
+		if len(report.Results) < 2 {
+			t.Errorf("expected at least two results, got %d", len(report.Results))
+		}
+
+		for _, result := range report.Results {
+			for _, secret := range result {
+				if secret.ValidationStatus == "" {
+					t.Errorf("expected validation status, got empty")
+				}
+			}
 		}
 	})
 }

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -14,12 +14,12 @@ func TestFilesystemIntegration(t *testing.T) {
 
 	projectDir := t.TempDir()
 
-	t.Run("found_one_secret", func(t *testing.T) {
+	t.Run("one secret found", func(t *testing.T) {
 		if err := generateProject(projectDir); err != nil {
 			t.Fatalf("failed to generate project: %s", err)
 		}
 
-		if err := executable.run(projectDir); err == nil {
+		if err := executable.run("filesystem", "--path", projectDir); err == nil {
 			t.Error("expected error, got nil")
 		}
 

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -2,7 +2,11 @@ package tests
 
 import "testing"
 
-func TestCLI(t *testing.T) {
+func TestFilesystemIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test")
+	}
+
 	executable, err := createCLI(t.TempDir())
 	if err != nil {
 		t.Fatalf("failed to build CLI: %s", err)


### PR DESCRIPTION
This pull request includes the following changes:

- Convert CLI to end-to-end tests

- Refactor the run function in the CLI struct

- Refactor e2e_test.go to add a confluence test