### PR TITLE
refactor: use interface for source item instead of struct

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -67,7 +67,7 @@ var allPlugins = []plugins.IPlugin{
 }
 
 var channels = plugins.Channels{
-	Items:     make(chan plugins.Item),
+	Items:     make(chan plugins.ISourceItem),
 	Errors:    make(chan error),
 	WaitGroup: &sync.WaitGroup{},
 }

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -61,17 +61,17 @@ func Init(engineConfig EngineConfig) (*Engine, error) {
 	}, nil
 }
 
-func (s *Engine) Detect(item plugins.Item, secretsChannel chan *secrets.Secret, wg *sync.WaitGroup, ignoredIds []string) {
+func (s *Engine) Detect(item plugins.ISourceItem, secretsChannel chan *secrets.Secret, wg *sync.WaitGroup, ignoredIds []string) {
 	defer wg.Done()
 
 	fragment := detect.Fragment{
-		Raw: item.Content,
+		Raw: *item.GetContent(),
 	}
 	for _, value := range s.detector.Detect(fragment) {
 		itemId := getFindingId(item, value)
 		secret := &secrets.Secret{
 			ID:          itemId,
-			Source:      item.Source,
+			Source:      item.GetSource(),
 			RuleID:      value.RuleID,
 			StartLine:   value.StartLine,
 			StartColumn: value.StartColumn,
@@ -113,8 +113,8 @@ func (s *Engine) Validate() {
 	s.validator.Validate()
 }
 
-func getFindingId(item plugins.Item, finding report.Finding) string {
-	idParts := []string{item.ID, finding.RuleID, finding.Secret}
+func getFindingId(item plugins.ISourceItem, finding report.Finding) string {
+	idParts := []string{item.GetID(), finding.RuleID, finding.Secret}
 	sha := sha1.Sum([]byte(strings.Join(idParts, "-")))
 	return fmt.Sprintf("%x", sha)
 }

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -126,7 +126,7 @@ func TestSecrets(t *testing.T) {
 			secretsChan := make(chan *secrets.Secret, 1)
 			wg := &sync.WaitGroup{}
 			wg.Add(1)
-			detector.Detect(plugins.Item{Content: secret.Content}, secretsChan, wg, nil)
+			detector.Detect(item{content: &secret.Content}, secretsChan, wg, nil)
 			close(secretsChan)
 
 			s := <-secretsChan
@@ -139,5 +139,20 @@ func TestSecrets(t *testing.T) {
 			}
 		})
 	}
+}
 
+type item struct {
+	content *string
+}
+
+var _ plugins.ISourceItem = (*item)(nil)
+
+func (i item) GetContent() *string {
+	return i.content
+}
+func (i item) GetID() string {
+	return "test"
+}
+func (i item) GetSource() string {
+	return "test"
 }

--- a/plugins/confluence.go
+++ b/plugins/confluence.go
@@ -35,7 +35,7 @@ type ConfluencePlugin struct {
 	History bool
 	client  IConfluenceClient
 
-	itemsChan  chan Item
+	itemsChan  chan ISourceItem
 	errorsChan chan error
 }
 
@@ -52,7 +52,7 @@ func isValidURL(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func (p *ConfluencePlugin) DefineCommand(items chan Item, errors chan error) (*cobra.Command, error) {
+func (p *ConfluencePlugin) DefineCommand(items chan ISourceItem, errors chan error) (*cobra.Command, error) {
 	p.itemsChan = items
 	p.errorsChan = errors
 
@@ -152,9 +152,9 @@ func (p *ConfluencePlugin) scanPageVersion(page ConfluencePage, space Confluence
 	return pageContent.History.PreviousVersion.Number
 }
 
-func convertPageToItem(pageContent *ConfluencePageContent, itemID string) Item {
-	return Item{
-		Content: pageContent.Body.Storage.Value,
+func convertPageToItem(pageContent *ConfluencePageContent, itemID string) ISourceItem {
+	return &item{
+		Content: &pageContent.Body.Storage.Value,
 		ID:      itemID,
 		Source:  pageContent.Links["base"] + pageContent.Links["webui"],
 	}

--- a/plugins/discord.go
+++ b/plugins/discord.go
@@ -30,7 +30,7 @@ type DiscordPlugin struct {
 	Session          *discordgo.Session
 
 	errChan   chan error
-	itemChan  chan Item
+	itemChan  chan ISourceItem
 	waitGroup *sync.WaitGroup
 }
 
@@ -38,7 +38,7 @@ func (p *DiscordPlugin) GetName() string {
 	return "discord"
 }
 
-func (p *DiscordPlugin) DefineCommand(items chan Item, errors chan error) (*cobra.Command, error) {
+func (p *DiscordPlugin) DefineCommand(items chan ISourceItem, errors chan error) (*cobra.Command, error) {
 	var discordCmd = &cobra.Command{
 		Use:   fmt.Sprintf("%s --%s TOKEN --%s SERVER", p.GetName(), tokenFlag, serversFlag),
 		Short: "Scan Discord server",
@@ -88,7 +88,7 @@ func (p *DiscordPlugin) initialize() error {
 	return nil
 }
 
-func (p *DiscordPlugin) getItems(itemsChan chan Item, errChan chan error, wg *sync.WaitGroup) {
+func (p *DiscordPlugin) getItems(itemsChan chan ISourceItem, errChan chan error, wg *sync.WaitGroup) {
 	p.errChan = errChan
 	p.itemChan = itemsChan
 	p.waitGroup = wg
@@ -276,11 +276,11 @@ func (p *DiscordPlugin) getMessages(channelID string, logger zerolog.Logger) ([]
 	return append(messages, threadMessages...), nil
 }
 
-func convertMessagesToItems(pluginName, guildId string, messages *[]*discordgo.Message) *[]Item {
-	items := []Item{}
+func convertMessagesToItems(pluginName, guildId string, messages *[]*discordgo.Message) *[]ISourceItem {
+	items := []ISourceItem{}
 	for _, message := range *messages {
-		items = append(items, Item{
-			Content: message.Content,
+		items = append(items, item{
+			Content: &message.Content,
 			ID:      fmt.Sprintf("%s-%s-%s-%s", pluginName, guildId, message.ChannelID, message.ID),
 			Source:  fmt.Sprintf("https://discord.com/channels/%s/%s/%s", guildId, message.ChannelID, message.ID),
 		})

--- a/plugins/filesystem.go
+++ b/plugins/filesystem.go
@@ -29,7 +29,7 @@ func (p *FileSystemPlugin) GetName() string {
 	return "filesystem"
 }
 
-func (p *FileSystemPlugin) DefineCommand(items chan Item, errors chan error) (*cobra.Command, error) {
+func (p *FileSystemPlugin) DefineCommand(items chan ISourceItem, errors chan error) (*cobra.Command, error) {
 	var cmd = &cobra.Command{
 		Use:   fmt.Sprintf("%s --%s PATH", p.GetName(), flagFolder),
 		Short: "Scan local folder",
@@ -59,7 +59,7 @@ func (p *FileSystemPlugin) DefineCommand(items chan Item, errors chan error) (*c
 	return cmd, nil
 }
 
-func (p *FileSystemPlugin) getFiles(items chan Item, errs chan error, wg *sync.WaitGroup) {
+func (p *FileSystemPlugin) getFiles(items chan ISourceItem, errs chan error, wg *sync.WaitGroup) {
 	fileList := make([]string, 0)
 	err := filepath.Walk(p.Path, func(path string, fInfo os.FileInfo, err error) error {
 		if err != nil {
@@ -99,7 +99,7 @@ func (p *FileSystemPlugin) getFiles(items chan Item, errs chan error, wg *sync.W
 	p.getItems(items, errs, wg, fileList)
 }
 
-func (p *FileSystemPlugin) getItems(items chan Item, errs chan error, wg *sync.WaitGroup, fileList []string) {
+func (p *FileSystemPlugin) getItems(items chan ISourceItem, errs chan error, wg *sync.WaitGroup, fileList []string) {
 	for _, filePath := range fileList {
 		wg.Add(1)
 		go func(filePath string) {
@@ -114,17 +114,18 @@ func (p *FileSystemPlugin) getItems(items chan Item, errs chan error, wg *sync.W
 	}
 }
 
-func (p *FileSystemPlugin) getItem(filePath string) (*Item, error) {
+func (p *FileSystemPlugin) getItem(filePath string) (*item, error) {
 	log.Debug().Str("file", filePath).Msg("reading file")
 	b, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, err
 	}
 
-	content := &Item{
-		Content: string(b),
+	content := string(b)
+	item := &item{
+		Content: &content,
 		ID:      fmt.Sprintf("%s-%s-%s", p.GetName(), p.ProjectName, filePath),
 		Source:  filePath,
 	}
-	return content, nil
+	return item, nil
 }

--- a/plugins/git.go
+++ b/plugins/git.go
@@ -31,7 +31,7 @@ func (p *GitPlugin) GetName() string {
 	return "git"
 }
 
-func (p *GitPlugin) DefineCommand(items chan Item, errors chan error) (*cobra.Command, error) {
+func (p *GitPlugin) DefineCommand(items chan ISourceItem, errors chan error) (*cobra.Command, error) {
 	p.Channels = Channels{
 		Items:     items,
 		Errors:    errors,
@@ -68,7 +68,7 @@ func (p *GitPlugin) buildScanOptions() string {
 	return strings.Join(options, " ")
 }
 
-func (p *GitPlugin) scanGit(path string, scanOptions string, itemsChan chan Item, errChan chan error) {
+func (p *GitPlugin) scanGit(path string, scanOptions string, itemsChan chan ISourceItem, errChan chan error) {
 	diffs, close := p.readGitLog(path, scanOptions, errChan)
 	defer close()
 
@@ -86,8 +86,8 @@ func (p *GitPlugin) scanGit(path string, scanOptions string, itemsChan chan Item
 			}
 		}
 		if fileChanges != "" {
-			itemsChan <- Item{
-				Content: fileChanges,
+			itemsChan <- item{
+				Content: &fileChanges,
 				ID:      fmt.Sprintf("%s-%s-%s-%s", p.GetName(), p.projectName, file.PatchHeader.SHA, file.NewName),
 				Source:  fmt.Sprintf("git show %s:%s", file.PatchHeader.SHA, file.NewName),
 			}

--- a/plugins/paligo.go
+++ b/plugins/paligo.go
@@ -55,7 +55,7 @@ func (p *PaligoPlugin) GetName() string {
 	return "paligo"
 }
 
-func (p *PaligoPlugin) DefineCommand(items chan Item, errors chan error) (*cobra.Command, error) {
+func (p *PaligoPlugin) DefineCommand(items chan ISourceItem, errors chan error) (*cobra.Command, error) {
 	p.Channels = Channels{
 		Items:     items,
 		Errors:    errors,
@@ -174,20 +174,20 @@ func (p *PaligoPlugin) processFolders(foldersToProcess []PaligoItem) chan Paligo
 	return itemsChan
 }
 
-func (p *PaligoPlugin) handleComponent(item PaligoItem) {
+func (p *PaligoPlugin) handleComponent(paligoItem PaligoItem) {
 
-	log.Info().Msgf("Getting component %s", item.Name)
-	document, err := p.paligoApi.showDocument(item.ID)
+	log.Info().Msgf("Getting component %s", paligoItem.Name)
+	document, err := p.paligoApi.showDocument(paligoItem.ID)
 	if err != nil {
-		log.Error().Err(err).Msgf("error while getting document '%s'", item.Name)
-		p.Channels.Errors <- fmt.Errorf("error while getting document '%s': %w", item.Name, err)
+		log.Error().Err(err).Msgf("error while getting document '%s'", paligoItem.Name)
+		p.Channels.Errors <- fmt.Errorf("error while getting document '%s': %w", paligoItem.Name, err)
 		return
 	}
 
 	url := fmt.Sprintf("https://%s.paligoapp.com/document/edit/%d", p.paligoApi.Instance, document.ID)
 
-	p.Items <- Item{
-		Content: document.Content,
+	p.Items <- item{
+		Content: &document.Content,
 		ID:      fmt.Sprintf("%s-%s-%d", p.GetName(), p.paligoApi.Instance, document.ID),
 		Source:  url,
 	}

--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -6,12 +6,32 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type Item struct {
-	Content string
+type ISourceItem interface {
+	GetContent() *string
+	GetID() string
+	GetSource() string
+}
+
+type item struct {
+	Content *string
 	// Unique identifier of the item
 	ID string
 	// User friendly description and/or link to the item
 	Source string
+}
+
+var _ ISourceItem = (*item)(nil)
+
+func (i item) GetContent() *string {
+	return i.Content
+}
+
+func (i item) GetID() string {
+	return i.ID
+}
+
+func (i item) GetSource() string {
+	return i.Source
 }
 
 type Plugin struct {
@@ -20,12 +40,12 @@ type Plugin struct {
 }
 
 type Channels struct {
-	Items     chan Item
+	Items     chan ISourceItem
 	Errors    chan error
 	WaitGroup *sync.WaitGroup
 }
 
 type IPlugin interface {
 	GetName() string
-	DefineCommand(items chan Item, errors chan error) (*cobra.Command, error)
+	DefineCommand(items chan ISourceItem, errors chan error) (*cobra.Command, error)
 }

--- a/plugins/slack.go
+++ b/plugins/slack.go
@@ -39,7 +39,7 @@ var (
 	messagesCountArg    int
 )
 
-func (p *SlackPlugin) DefineCommand(items chan Item, errors chan error) (*cobra.Command, error) {
+func (p *SlackPlugin) DefineCommand(items chan ISourceItem, errors chan error) (*cobra.Command, error) {
 	p.Channels = Channels{
 		Items:     items,
 		Errors:    errors,
@@ -130,8 +130,8 @@ func (p *SlackPlugin) getItemsFromChannel(slackApi *slack.Client, channel slack.
 					log.Warn().Msgf("Error while getting permalink for message %s: %s", message.Timestamp, err)
 					url = fmt.Sprintf("Channel: %s; Message: %s", channel.Name, message.Timestamp)
 				}
-				p.Items <- Item{
-					Content: message.Text,
+				p.Items <- item{
+					Content: &message.Text,
 					ID:      fmt.Sprintf("%s-%s-%s", p.GetName(), channel.ID, message.Timestamp),
 					Source:  url,
 				}


### PR DESCRIPTION
This pull request updates the code to use an interface for the source item instead of a struct. This change improves code flexibility and maintainability.