### PR TITLE
feat: ignore files that not scanned usually

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -32,11 +32,11 @@ jobs:
       - name: Go Linter
         run: docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:v1.52.0 golangci-lint run -v -E gofmt --timeout=5m --out-format github-actions
 
-      - name: Run 2ms Scan
-        run: go run . git . --config .2ms.yml
-
       - name: Go Test
         run: go test -v ./...
+
+      - name: Run 2ms Scan
+        run: go run . git . --config .2ms.yml
 
   build:
     runs-on: ubuntu-latest

--- a/engine/config.go
+++ b/engine/config.go
@@ -1,0 +1,25 @@
+package engine
+
+import (
+	"regexp"
+
+	"github.com/zricethezav/gitleaks/v8/config"
+)
+
+// Taken from gitleaks config https://github.com/gitleaks/gitleaks/blob/6c52f878cc48a513849900a9aa6f9d68e1c2dbdd/config/gitleaks.toml#L15-L26
+var cfg = config.Config{
+	Allowlist: config.Allowlist{
+		Paths: []*regexp.Regexp{
+			regexp.MustCompile(`gitleaks.toml`),
+			regexp.MustCompile(`(.*?)(jpg|gif|doc|docx|zip|xls|pdf|bin|svg|socket|vsidx|v2|suo|wsuo|.dll|pdb|exe)$`),
+			regexp.MustCompile(`(go.mod|go.sum)$`),
+			regexp.MustCompile(`gradle.lockfile`),
+			regexp.MustCompile(`node_modules`),
+			regexp.MustCompile(`package-lock.json`),
+			regexp.MustCompile(`yarn.lock`),
+			regexp.MustCompile(`pnpm-lock.yaml`),
+			regexp.MustCompile(`Database.refactorlog`),
+			regexp.MustCompile(`vendor`),
+		},
+	},
+}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -48,10 +48,9 @@ func Init(engineConfig EngineConfig) (*Engine, error) {
 		rule.Rule.Keywords = []string{}
 		rulesToBeApplied[rule.Rule.RuleID] = rule.Rule
 	}
+	cfg.Rules = rulesToBeApplied
 
-	detector := detect.NewDetector(config.Config{
-		Rules: rulesToBeApplied,
-	})
+	detector := detect.NewDetector(cfg)
 	detector.MaxTargetMegaBytes = engineConfig.MaxTargetMegabytes
 
 	return &Engine{
@@ -65,7 +64,8 @@ func (s *Engine) Detect(item plugins.ISourceItem, secretsChannel chan *secrets.S
 	defer wg.Done()
 
 	fragment := detect.Fragment{
-		Raw: *item.GetContent(),
+		Raw:      *item.GetContent(),
+		FilePath: item.GetSource(),
 	}
 	for _, value := range s.detector.Detect(fragment) {
 		itemId := getFindingId(item, value)

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -10,8 +10,6 @@ import (
 	"github.com/checkmarx/2ms/plugins"
 )
 
-var github_token = "ghp_vF93MdvGWEQkB7t" + "5csik0Vdsy2q99P3Nje1s"
-
 func Test_Init(t *testing.T) {
 	allRules := *rules.FilterRules([]string{}, []string{}, []string{})
 	specialRule := rules.HardcodedPassword()
@@ -65,8 +63,9 @@ func Test_Init(t *testing.T) {
 
 func TestDetector(t *testing.T) {
 	t.Run("ignore go.sum file", func(t *testing.T) {
+		token := "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"
 		i := item{
-			content: &github_token,
+			content: &token,
 			source:  "path/to/go.sum",
 		}
 
@@ -115,7 +114,7 @@ func TestSecrets(t *testing.T) {
 			ShouldFind: true,
 		},
 		{
-			Content:    github_token,
+			Content:    "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",
 			Name:       "GitHub Personal Access Token",
 			ShouldFind: true,
 		},

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/checkmarx/2ms/plugins"
 )
 
+var github_token = "ghp_vF93MdvGWEQkB7t" + "5csik0Vdsy2q99P3Nje1s"
+
 func Test_Init(t *testing.T) {
 	allRules := *rules.FilterRules([]string{}, []string{}, []string{})
 	specialRule := rules.HardcodedPassword()
@@ -63,9 +65,8 @@ func Test_Init(t *testing.T) {
 
 func TestDetector(t *testing.T) {
 	t.Run("ignore go.sum file", func(t *testing.T) {
-		token := "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"
 		i := item{
-			content: &token,
+			content: &github_token,
 			source:  "path/to/go.sum",
 		}
 
@@ -114,7 +115,7 @@ func TestSecrets(t *testing.T) {
 			ShouldFind: true,
 		},
 		{
-			Content:    "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",
+			Content:    github_token,
 			Name:       "GitHub Personal Access Token",
 			ShouldFind: true,
 		},

--- a/tests/e2e.go
+++ b/tests/e2e.go
@@ -43,11 +43,11 @@ func createCLI(outputDir string) (cli, error) {
 		nil
 }
 
-func generateProject(outputDir string) error {
+func generateFileWithSecret(outputDir string, filename string) error {
 	token := "g" + "hp" + "_ixOl" + "iEFNK4O" + "brYB506" + "8oXFd" + "9JUF" + "iRy0RU" + "KNl"
 	content := "bla bla bla\nGitHubToken: " + token + "\nbla bla bla"
 
-	if err := os.WriteFile(path.Join(outputDir, "secret.txt"), []byte(content), 0644); err != nil {
+	if err := os.WriteFile(path.Join(outputDir, filename), []byte(content), 0644); err != nil {
 		return err
 	}
 

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -15,7 +15,7 @@ func TestIntegration(t *testing.T) {
 	t.Run("filesystem: one secret found", func(t *testing.T) {
 		projectDir := t.TempDir()
 
-		if err := generateProject(projectDir); err != nil {
+		if err := generateFileWithSecret(projectDir, "secret.txt"); err != nil {
 			t.Fatalf("failed to generate project: %s", err)
 		}
 
@@ -53,6 +53,27 @@ func TestIntegration(t *testing.T) {
 					t.Errorf("expected validation status, got empty")
 				}
 			}
+		}
+	})
+
+	t.Run("filesystem: ignore go.sum file", func(t *testing.T) {
+		projectDir := t.TempDir()
+
+		if err := generateFileWithSecret(projectDir, "go.sum"); err != nil {
+			t.Fatalf("failed to generate project: %s", err)
+		}
+
+		if err := executable.run("filesystem", "--path", projectDir); err != nil {
+			t.Errorf("expected no error, got %s", err)
+		}
+
+		report, err := executable.getReport()
+		if err != nil {
+			t.Fatalf("failed to get report: %s", err)
+		}
+
+		if len(report.Results) != 0 {
+			t.Errorf("expected no results, got %d", len(report.Results))
 		}
 	})
 }


### PR DESCRIPTION
Copied from _gitleaks_ the "Allowlist" paths: paths that we didn't expect to find a secret there.

```
gitleaks.toml
(.*?)(jpg|gif|doc|docx|zip|xls|pdf|bin|svg|socket|vsidx|v2|suo|wsuo|.dll|pdb|exe)$
(go.mod|go.sum)$
gradle.lockfile
node_modules
package-lock.json
yarn.lock
pnpm-lock.yaml
Database.refactorlog
vendor
```