### PR TITLE
Add 1 to start and end line for filesystem cases

### DIFF
--- a/cmd/workers.go
+++ b/cmd/workers.go
@@ -6,14 +6,14 @@ import (
 	"github.com/checkmarx/2ms/engine"
 )
 
-func processItems(engine *engine.Engine) {
+func processItems(engine *engine.Engine, pluginName string) {
 	defer channels.WaitGroup.Done()
 
 	wgItems := &sync.WaitGroup{}
 	for item := range channels.Items {
 		report.TotalItemsScanned++
 		wgItems.Add(1)
-		go engine.Detect(item, secretsChan, wgItems, ignoreVar)
+		go engine.Detect(item, secretsChan, wgItems, ignoreVar, pluginName)
 	}
 	wgItems.Wait()
 	close(secretsChan)

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -60,7 +60,7 @@ func Init(engineConfig EngineConfig) (*Engine, error) {
 	}, nil
 }
 
-func (s *Engine) Detect(item plugins.ISourceItem, secretsChannel chan *secrets.Secret, wg *sync.WaitGroup, ignoredIds []string) {
+func (s *Engine) Detect(item plugins.ISourceItem, secretsChannel chan *secrets.Secret, wg *sync.WaitGroup, ignoredIds []string, pluginName string) {
 	defer wg.Done()
 
 	fragment := detect.Fragment{
@@ -69,13 +69,21 @@ func (s *Engine) Detect(item plugins.ISourceItem, secretsChannel chan *secrets.S
 	}
 	for _, value := range s.detector.Detect(fragment) {
 		itemId := getFindingId(item, value)
+		var startLine, endLine int
+		if pluginName == "filesystem" {
+			startLine = value.StartLine + 1
+			endLine = value.EndLine + 1
+		} else {
+			startLine = value.StartLine
+			endLine = value.EndLine
+		}
 		secret := &secrets.Secret{
 			ID:          itemId,
 			Source:      item.GetSource(),
 			RuleID:      value.RuleID,
-			StartLine:   value.StartLine,
+			StartLine:   startLine,
 			StartColumn: value.StartColumn,
-			EndLine:     value.EndLine,
+			EndLine:     endLine,
 			EndColumn:   value.EndColumn,
 			Value:       value.Secret,
 		}


### PR DESCRIPTION
Similarly to [gitleaks](https://github.com/gitleaks/gitleaks/blob/79cac73f7267f4a48f4bc73db11e105a6098a836/detect/directory.go#L72) (whose change was added in [version 8.1.3](https://github.com/gitleaks/gitleaks/releases/tag/v8.1.3)), it is necessary to increment the start and end line for filesystem cases.

**Checklist**

- [x] I covered my changes with tests.
- [x] I Updated the documentation that is affected by my changes:
  - [ ] Change in the CLI arguments
  - [ ] Change in the configuration file
