### PR TITLE
feat: add line content to 2ms results

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -98,7 +98,7 @@ func (e *Engine) Detect(item plugins.ISourceItem, secretsChannel chan *secrets.S
 			EndLine:     endLine,
 			EndColumn:   value.EndColumn,
 			Value:       value.Secret,
-			Line:        value.Line,
+			LineContent: value.Line,
 		}
 		if !isSecretIgnored(secret, &e.ignoredIds, &e.allowedValues) {
 			secretsChannel <- secret

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -98,6 +98,7 @@ func (e *Engine) Detect(item plugins.ISourceItem, secretsChannel chan *secrets.S
 			EndLine:     endLine,
 			EndColumn:   value.EndColumn,
 			Value:       value.Secret,
+			Line:        value.Line,
 		}
 		if !isSecretIgnored(secret, &e.ignoredIds, &e.allowedValues) {
 			secretsChannel <- secret

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"sync"
 	"testing"
 
@@ -159,11 +160,10 @@ func TestSecrets(t *testing.T) {
 
 			s := <-secretsChan
 
-			if s == nil && secret.ShouldFind {
-				t.Errorf("secret \"%s\" not found", secret.Name)
-			}
-			if s != nil && !secret.ShouldFind {
-				t.Errorf("should not find")
+			if secret.ShouldFind {
+				assert.Equal(t, s.LineContent, secret.Content)
+			} else {
+				assert.Nil(t, s)
 			}
 		})
 	}

--- a/lib/reporting/sarif.go
+++ b/lib/reporting/sarif.go
@@ -92,6 +92,7 @@ func getLocation(secret *secrets.Secret) []Locations {
 					EndColumn:   secret.EndColumn,
 					Snippet: Snippet{
 						Text: secret.Value,
+						Line: secret.Line,
 					},
 				},
 			},
@@ -135,6 +136,7 @@ type Region struct {
 
 type Snippet struct {
 	Text string `json:"text"`
+	Line string `json:"line"`
 }
 
 type PhysicalLocation struct {

--- a/lib/reporting/sarif.go
+++ b/lib/reporting/sarif.go
@@ -92,7 +92,9 @@ func getLocation(secret *secrets.Secret) []Locations {
 					EndColumn:   secret.EndColumn,
 					Snippet: Snippet{
 						Text: secret.Value,
-						Line: secret.Line,
+						Properties: Properties{
+							"lineContent": secret.LineContent,
+						},
 					},
 				},
 			},
@@ -135,8 +137,8 @@ type Region struct {
 }
 
 type Snippet struct {
-	Text string `json:"text"`
-	Line string `json:"line"`
+	Text       string     `json:"text"`
+	Properties Properties `json:"properties,omitempty"`
 }
 
 type PhysicalLocation struct {

--- a/lib/reporting/sarif.go
+++ b/lib/reporting/sarif.go
@@ -3,9 +3,9 @@ package reporting
 import (
 	"encoding/json"
 	"fmt"
-
 	"github.com/checkmarx/2ms/lib/config"
 	"github.com/checkmarx/2ms/lib/secrets"
+	"strings"
 )
 
 func writeSarif(report Report, cfg *config.Config) (string, error) {
@@ -93,7 +93,7 @@ func getLocation(secret *secrets.Secret) []Locations {
 					Snippet: Snippet{
 						Text: secret.Value,
 						Properties: Properties{
-							"lineContent": secret.LineContent,
+							"lineContent": strings.TrimSpace(secret.LineContent),
 						},
 					},
 				},

--- a/lib/secrets/secret.go
+++ b/lib/secrets/secret.go
@@ -38,7 +38,7 @@ type Secret struct {
 	RuleID           string                 `json:"ruleId"`
 	StartLine        int                    `json:"startLine"`
 	EndLine          int                    `json:"endLine"`
-	Line             string                 `json:"line"`
+	LineContent      string                 `json:"lineContent"`
 	StartColumn      int                    `json:"startColumn"`
 	EndColumn        int                    `json:"endColumn"`
 	Value            string                 `json:"value"`

--- a/lib/secrets/secret.go
+++ b/lib/secrets/secret.go
@@ -38,6 +38,7 @@ type Secret struct {
 	RuleID           string                 `json:"ruleId"`
 	StartLine        int                    `json:"startLine"`
 	EndLine          int                    `json:"endLine"`
+	Line             string                 `json:"line"`
 	StartColumn      int                    `json:"startColumn"`
 	EndColumn        int                    `json:"endColumn"`
 	Value            string                 `json:"value"`


### PR DESCRIPTION
To analyse the entire value of the line where the secret was detected, 2ms now takes the `Line` information from gitleaks.

**Checklist**

- [x] I covered my changes with tests.
- [ ] I Updated the documentation that is affected by my changes:
  - [ ] Change in the CLI arguments
  - [ ] Change in the configuration file