### PR TITLE
ci: ast-43499 add codecov scan workflow

### DIFF
--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -1,0 +1,47 @@
+
+name: Codecov Scan
+
+on:
+  push:
+    branches:
+      - main 
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    env:
+      go-version: 'stable'
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+    - name: Set up Go
+      uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      with:
+        go-version: ${{ env.go-version }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        GOPROXY: direct
+        GONOSUMDB: "*"
+        GOPRIVATE: https://github.com/CheckmarxDev/ # Add your private organization url here
+
+    - name: Install dependencies 
+      run: go install golang.org/x/tools/cmd/cover@latest
+
+    - name: Run tests and generate coverage 
+      run: |
+        git config --global url."https://${{ secrets.GH_TOKEN }}@github.com".insteadOf "https://github.com"
+        go test ./... -coverpkg=./... -v -coverprofile cover.out
+                  
+         
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@84508663e988701840491b86de86b666e8a86bed # v4.3.0
+      with:
+        token: ${{ secrets.CODECOV_MICRO_ENGINES_ORG_TOKEN }} 
+        files: ./cover.out  
+        flags: target=auto
+        fail_ci_if_error: true
+        verbose: false

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -23,7 +23,6 @@ jobs:
       with:
         go-version: ${{ env.go-version }}
       env:
-        GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         GOPROXY: direct
         GONOSUMDB: "*"
         GOPRIVATE: https://github.com/CheckmarxDev/ # Add your private organization url here
@@ -33,7 +32,6 @@ jobs:
 
     - name: Run tests and generate coverage 
       run: |
-        git config --global url."https://${{ secrets.GH_TOKEN }}@github.com".insteadOf "https://github.com"
         go test ./... -coverpkg=./... -v -coverprofile cover.out
                   
          

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -40,7 +40,7 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@84508663e988701840491b86de86b666e8a86bed # v4.3.0
       with:
-        token: ${{ secrets.CODECOV_MICRO_ENGINES_ORG_TOKEN }} 
+        token: ${{ secrets.CODECOV_TOKEN }} 
         files: ./cover.out  
         flags: target=auto
         fail_ci_if_error: true


### PR DESCRIPTION
adding codecov scan workflow to the repo.
it will trigger on PR and after merge to master.
it is NOT a blocker - even if it's fail.