### PR TITLE
chore: update go image to 1.23.6

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -60,8 +60,8 @@ jobs:
           trivy-config: trivy.yaml
           exit-code: '1'
         env:
-          TRIVY_SKIP_DB_UPDATE: true
-          TRIVY_SKIP_JAVA_DB_UPDATE: true
+          TRIVY_SKIP_DB_UPDATE: false
+          TRIVY_SKIP_JAVA_DB_UPDATE: false
 
 
   secret-scanning:

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY . .
 RUN GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -a -o /app/2ms .
 
 # Runtime image
-FROM cgr.dev/chainguard/git@sha256:d32fb4fbb132929abae2d2f742e3d3bfdbd4937caa7021299130ad096227ced0
+FROM cgr.dev/chainguard/git@sha256:1169e026c3296ffa346bc2035f08a3397a22cc72753669a943435518022fd270
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # and "Missing User Instruction" since 2ms container is stopped after scan
 
 # Builder image
-FROM cgr.dev/chainguard/go@sha256:bec4bfc80786869dc30beca3d0bd437bd932f376dc6ac5b1f4dd6a5355ba11fc AS builder
+FROM cgr.dev/chainguard/go@sha256:36fee4a2334d13bbf585ad2225ea1ca99fe65de366022e561ac157de26fd5ed6 AS builder
 
 WORKDIR /app
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/checkmarx/2ms
 
-go 1.23.5
+go 1.23.6
 
 require (
 	github.com/bwmarrin/discordgo v0.27.1


### PR DESCRIPTION
Updating go image to 1.23.6 due to security fixes in go