### PR TITLE
feat: add log level none flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,11 @@ COPY . .
 RUN GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -a -o /app/2ms .
 
 # Runtime image
-FROM cgr.dev/chainguard/git@sha256:2545cd570d26257e45c9d302cc459816ffc1e97de90d31e599782d56be7ab40e
+FROM cgr.dev/chainguard/git@sha256:b0dbd0c3c6a0f44c0522663c3a7f9b47f8e62ed419c88c37199f61308f19829c
 
 WORKDIR /app
 
-COPY --chown=65532:65532 --from=builder /app/2ms /app/2ms
+RUN chown -R 65532:65532 /app
 
 USER 65532
 

--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ The following table describes the global flags that can be used together with an
 |--ignore-on-exit |  | None | Defines which kind of non-zero exits code should be ignored. Options are: all, results, errors, none. For example, if 'results' is set, only engine errors will make 2ms exit code different from 0. |
 |--ignore-result | strings |  | Ignore specific result by ID |
 |--ignore-rule | strings |  | Ignore rules by name or tag. |
-|--log-level | string | info | Type of log to return. Options are: trace, debug, info, warn, error, fatal |
+|--log-level | string | info | Type of log to return. Options are: trace, debug, info, warn, error, fatal, none |
 |--max-target-megabytes | int |  | Files larger than than the specified threshold will be skipped. Omit or set to 0 to disable this check. |
 |--regex | stringArray |  | Custom regexes to apply to the scan. Must be valid Go regex. |
 |--report-path | strings |  | Path to generate report files. The output format will be determined by the file extension (.json, .yaml, .sarif) |

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -26,7 +26,7 @@ func initialize() {
 	logLevel := zerolog.InfoLevel
 	switch strings.ToLower(logLevelVar) {
 	case "none":
-		logLevel = zerolog.Level(10)
+		logLevel = zerolog.Disabled
 	case "trace":
 		logLevel = zerolog.TraceLevel
 	case "debug":

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -13,6 +13,7 @@ import (
 )
 
 func initialize() {
+
 	configFilePath, err := rootCmd.Flags().GetString(configFileFlag)
 	if err != nil {
 		cobra.CheckErr(err)
@@ -20,8 +21,12 @@ func initialize() {
 	cobra.CheckErr(utils.LoadConfig(vConfig, configFilePath))
 	cobra.CheckErr(utils.BindFlags(rootCmd, vConfig, envPrefix))
 
+	logLevelVar, _ = rootCmd.Flags().GetString(logLevelFlagName)
+
 	logLevel := zerolog.InfoLevel
 	switch strings.ToLower(logLevelVar) {
+	case "none":
+		logLevel = zerolog.Level(10)
 	case "trace":
 		logLevel = zerolog.TraceLevel
 	case "debug":

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -85,7 +85,7 @@ func Execute() (int, error) {
 	cobra.OnInitialize(initialize)
 	rootCmd.PersistentFlags().StringVar(&configFilePath, configFileFlag, "", "config file path")
 	cobra.CheckErr(rootCmd.MarkPersistentFlagFilename(configFileFlag, "yaml", "yml", "json"))
-	rootCmd.PersistentFlags().StringVar(&logLevelVar, logLevelFlagName, "info", "log level (trace, debug, info, warn, error, fatal)")
+	rootCmd.PersistentFlags().StringVar(&logLevelVar, logLevelFlagName, "info", "log level (trace, debug, info, warn, error, fatal, none)")
 	rootCmd.PersistentFlags().StringSliceVar(&reportPathVar, reportPathFlagName, []string{}, "path to generate report files. The output format will be determined by the file extension (.json, .yaml, .sarif)")
 	rootCmd.PersistentFlags().StringVar(&stdoutFormatVar, stdoutFormatFlagName, "yaml", "stdout output format, available formats are: json, yaml, sarif")
 	rootCmd.PersistentFlags().StringArrayVar(&customRegexRuleVar, customRegexRuleFlagName, []string{}, "custom regexes to apply to the scan, must be valid Go regex")

--- a/lib/reporting/report.go
+++ b/lib/reporting/report.go
@@ -5,8 +5,11 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/checkmarx/2ms/lib/utils"
+
 	"github.com/checkmarx/2ms/lib/config"
 	"github.com/checkmarx/2ms/lib/secrets"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
 
@@ -64,6 +67,9 @@ func (r *Report) GetOutput(format string, cfg *config.Config) (string, error) {
 	var output string
 	var err error
 
+	if zerolog.GlobalLevel() == utils.NoneLevel {
+		return "", nil
+	}
 	switch format {
 	case jsonFormat:
 		output, err = writeJson(r)

--- a/lib/reporting/report_test.go
+++ b/lib/reporting/report_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/checkmarx/2ms/lib/config"
 	"github.com/checkmarx/2ms/lib/secrets"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
 )
@@ -229,6 +230,9 @@ func TestWriteReportInNonExistingDir(t *testing.T) {
 }
 
 func TestGetOutputSarif(t *testing.T) {
+
+	zerolog.SetGlobalLevel(zerolog.InfoLevel)
+
 	tests := []struct {
 		name    string
 		arg     Report

--- a/lib/utils/flags.go
+++ b/lib/utils/flags.go
@@ -5,11 +5,14 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
+
+var NoneLevel = zerolog.Level(-1)
 
 func LoadConfig(v *viper.Viper, configFilePath string) error {
 	if configFilePath == "" {


### PR DESCRIPTION
**Proposed Changes**


This PR introduces a new none log level which, when selected, disables all output to stdout. This allows for quieter execution and reduces computational overhead during runs where logging is unnecessary.


