### PR TITLE
fix: use line relative to file instead of relative to chunk

### DIFF
--- a/engine/chunk/chunk.go
+++ b/engine/chunk/chunk.go
@@ -106,6 +106,11 @@ func (c *Chunk) PutBuf(window *bytes.Buffer) {
 // GetPeekedBuf returns a fixed-size []byte from the pool
 func (c *Chunk) GetPeekedBuf() (*[]byte, bool) {
 	b, ok := c.peekedBufPool.Get().(*[]byte)
+	if !ok {
+		return nil, false
+	}
+	// reslice to its full capacity so Read can fill it
+	*b = (*b)[:cap(*b)]
 	return b, ok
 }
 

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -423,7 +423,7 @@ func TestDetectChunks(t *testing.T) {
 			tmp := t.TempDir()
 			src := tc.makeFile(tmp)
 
-			err := engine.detectChunks(&item{source: src}, make(chan *secrets.Secret, 1))
+			err := engine.detectChunks(context.Background(), &item{source: src}, make(chan *secrets.Secret, 1))
 			loggedMessage := logsBuffer.String()
 			if tc.expectedErr != nil {
 				require.ErrorContains(t, err, tc.expectedErr.Error())


### PR DESCRIPTION
**Proposed Changes**

- Fixed start and end line of secret when chunking is used 
  - Instead of calculating the line taking into account only the chunk, it also considers the context of the file. At the moment, we use context variables to pass on information about the lines in the chunks, **but this is a temporary solution until the engine instance is restructured**.

**Checklist**

- [ ] I covered my changes with tests.
- [ ] I Updated the documentation that is affected by my changes:
  - [ ] Change in the CLI arguments
  - [ ] Change in the configuration file