### PR TITLE
fix: adjust chunk size of git diff and fix id of item

### DIFF
--- a/plugins/git.go
+++ b/plugins/git.go
@@ -20,7 +20,7 @@ const (
 	AddedContent DiffType = iota
 	RemovedContent
 
-	maxChunkSize = 1024 * 1024 // 1MB max chunk size for git diff content
+	maxChunkSize = 256 * 1024 // 256KB max chunk size for git diff content (optimized for regexp)
 )
 
 const (
@@ -369,7 +369,7 @@ func (p *GitPlugin) processFileDiff(file *gitdiff.File, itemsChan chan ISourceIt
 		if chunk.Removed != "" {
 			itemsChan <- item{
 				Content: &chunk.Removed,
-				ID:      id + "-removed",
+				ID:      id,
 				Source:  source,
 				GitInfo: &GitInfo{
 					Hunks:       file.TextFragments,

--- a/plugins/git_test.go
+++ b/plugins/git_test.go
@@ -496,14 +496,14 @@ func TestExtractChanges(t *testing.T) {
 		{
 			name:           "Large diff chunked properly",
 			fragments:      createLargeTestFragments(2 * 1024 * 1024), // 2MB total
-			expectedChunks: 2,
-			description:    "Should create 2 chunks for 2MB of data with 1MB chunk size",
+			expectedChunks: 8,
+			description:    "Should create 8 chunks for 2MB of data with 256KB each",
 		},
 		{
 			name:           "Small diff single chunk",
 			fragments:      createSmallTestFragments(500 * 1024), // 500KB total
 			expectedChunks: 1,
-			description:    "Should create 1 chunk for 500KB of data with 1MB chunk size",
+			description:    "Should create 2 chunks for 500KB",
 		},
 		{
 			name:           "Empty fragments",
@@ -520,7 +520,7 @@ func TestExtractChanges(t *testing.T) {
 		{
 			name:           "Mixed operations",
 			fragments:      createMixedOperationFragments(256 * 1024), // 256KB each add/delete (total ~640KB)
-			expectedChunks: 1,
+			expectedChunks: 3,
 			description:    "Should handle mixed add/delete operations in single chunk",
 		},
 	}


### PR DESCRIPTION
<!--
Thanks for contributing to 2ms by offering a pull request.
-->

Closes #

**Proposed Changes**

- Adjust the size of chunk to at most have 256KB since it improves the regexp handling performance (~15% faster)
- Fix the id of the removed git diff

<!--
Please describe the big picture of your changes here. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

**Checklist**

- [ ] I covered my changes with tests.
- [ ] I Updated the documentation that is affected by my changes:
  - [ ] Change in the CLI arguments
  - [ ] Change in the configuration file

I submit this contribution under the Apache-2.0 license.
