### PR TITLE
feat: add version override option to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,11 @@ name: Release
 
 on:
   workflow_dispatch:
+    inputs:
+      version_override:
+        description: 'Override semantic version (e.g., v4.3.0) - leave empty for automatic calculation'
+        required: false
+        type: string
   push:
     branches: [master]
 
@@ -11,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
-      git_tag: ${{ steps.semantic_release_info.outputs.git_tag }}
-      version: ${{ steps.semantic_release_info.outputs.version }}
-      notes: ${{ steps.semantic_release_info.outputs.notes }}
+      git_tag: ${{ steps.semantic_release_info.outputs.git_tag || steps.version_override.outputs.git_tag }}
+      version: ${{ steps.semantic_release_info.outputs.version || steps.version_override.outputs.version }}
+      notes: ${{ steps.semantic_release_info.outputs.notes || steps.version_override.outputs.notes }}
     steps:
       - name: Checkout code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -31,10 +36,19 @@ jobs:
 
       - name: Gets release info
         id: semantic_release_info
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.version_override == ''
         uses: jossef/action-semantic-release-info@277fc891fc5ac40ed0e8d6bf59a0e24a25dfdeac #v3.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Override version if specified
+        id: version_override
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.version_override != ''
+        run: |
+          echo "Using manual version override: ${{ github.event.inputs.version_override }}"
+          echo "git_tag=${{ github.event.inputs.version_override }}" >> $GITHUB_OUTPUT
+          echo "version=$(echo '${{ github.event.inputs.version_override }}' | sed 's/^v//')" >> $GITHUB_OUTPUT
+          echo "notes=Manual release with version override to ${{ github.event.inputs.version_override }}" >> $GITHUB_OUTPUT
 
   build:
     name: Build and Release


### PR DESCRIPTION
Fixes semantic versioning issues when tags are out of sync

<!--
Thanks for contributing to 2ms by offering a pull request.
-->

Closes #

**Proposed Changes**

- Add manual version override input to release workflow

<!--
Please describe the big picture of your changes here. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

**Checklist**

- [ ] I covered my changes with tests.
- [ ] I Updated the documentation that is affected by my changes:
  - [ ] Change in the CLI arguments
  - [ ] Change in the configuration file

I submit this contribution under the Apache-2.0 license.
