### PR TITLE
fix: add support for xml generic token

### DIFF
--- a/.2ms.yml
+++ b/.2ms.yml
@@ -1389,3 +1389,5 @@ ignore-result:
 - 1ab798f14ecce9ea8a9229803c33f06e0093306a # unit test from generic_credential_test.go (remove later)
 - 4154ccf54f5d43a54103495dcf0e228353dc02f4 # unit test from generic_credential_test.go (remove later)
 - 783d3aa8f0e14f6d1527879bbcb3ae6195134b33 # unit test from generic_credential_test.go (remove later)
+- 4b68fb6117b9245a27ff07671dbad3b7734ad9f3 # unit test from generic_credential_test.go
+- de0438bff48b729dad27525d63839271790dca00 # unit test from generic_credential_test.go

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -60,7 +60,7 @@ jobs:
       - run: mkdir -p kics-results
 
       - name: Run KICS scan
-        uses: checkmarx/kics-github-action@03c9abe351b01c3e4dbe60fa00ff79ee07d73f44 # master
+        uses: checkmarx/kics-github-action@05aa5eb70eede1355220f4ca5238d96b397e30a6 # 2.1.20
         with:
           path: .
           output_path: kics-results

--- a/engine/rules/ruledefine/generic_credential.go
+++ b/engine/rules/ruledefine/generic_credential.go
@@ -107,6 +107,8 @@ func GenericCredential() *Rule {
 					regexp.MustCompile(`--mount=type=secret,`).String(),
 					//  https://github.com/gitleaks/gitleaks/issues/1800
 					regexp.MustCompile(`import[ \t]+{[ \t\w,]+}[ \t]+from[ \t]+['"][^'"]+['"]`).String(),
+					// Rails CSRF: name="authenticity_token" value="..." (matched via value= bridge)
+					regexp.MustCompile(`(?i)name\s*=\s*["']authenticity_token["']`).String(),
 				},
 			},
 			{

--- a/engine/rules/ruledefine/generic_credential.go
+++ b/engine/rules/ruledefine/generic_credential.go
@@ -107,7 +107,7 @@ func GenericCredential() *Rule {
 					regexp.MustCompile(`--mount=type=secret,`).String(),
 					//  https://github.com/gitleaks/gitleaks/issues/1800
 					regexp.MustCompile(`import[ \t]+{[ \t\w,]+}[ \t]+from[ \t]+['"][^'"]+['"]`).String(),
-					// Rails CSRF: name="authenticity_token" value="..." (matched via value= bridge)
+					// Example case: name="authenticity_token" value="..."
 					regexp.MustCompile(`(?i)name\s*=\s*["']authenticity_token["']`).String(),
 				},
 			},

--- a/engine/rules/ruledefine/generic_credential_test.go
+++ b/engine/rules/ruledefine/generic_credential_test.go
@@ -85,6 +85,8 @@ func TestGenericCredential(t *testing.T) {
 				" utils.GetEnvOrDefault(\"api_token\", \"dafa7817-e246-48f3-91a7-e87653d587b8\")",
 				// xml cases
 				"<key>API_KEY</key>\n<string>AIzaSyATDL7Wz3Ze6BU31Yv3fVVth30Skyib29g</string>",
+				`<Parameter name="github_token" value="ghp_1234567890abcdefghijklmnopqrstuv"/>`,
+				`<Parameter name="jwt_secret" value="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"/>`,
 			},
 			falsePositives: []string{
 				"issuerKeyHash=npmXsmT2_C1iJZ-SD7RuL8exZ=6ucd",

--- a/engine/rules/ruledefine/utils.go
+++ b/engine/rules/ruledefine/utils.go
@@ -19,17 +19,13 @@ const (
 	identifierSuffix                = `)(?:[ \t\w.-]{0,20})[\s'"]{0,3}`
 	identifierSuffixIncludingXml    = `)(?:[0-9a-z\-_\t .]{0,20})(?:<\/key>\s{0,10}<string)?(?:[\s|']|[\s|"]){0,3}`
 
-	// xmlAttributeValuePair bridges identifier (e.g. name="github_token") to the secret in
-	// <Parameter name="..." value="secret"/> and similar patterns.
-	xmlAttributeValuePair = `(?:\s*value\s*=\s*["'])?`
-
 	// commonly used assignment operators or function call
 	// operator = `(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)`
 	operator = `(?:=|>|:{1,3}=|\|\||:|=>|\?=|,)`
 
-	// optionalOperator allows YAML/JSON (operator required or absorbed by secretPrefix) and XML
-	// Parameter lines where xmlAttributeValuePair consumed value=" and the secret follows immediately.
-	optionalOperator = `(?:` + operator + `)?`
+	// operatorOrXmlValue requires either a normal assignment operator (YAML, JSON, plist `>` after
+	// <string>, etc.) or XML attribute value="..." (e.g. <Parameter name="github_token" value="..."/>).
+	operatorOrXmlValue = `(?:(?:\s*value\s*=\s*["'])|(?:` + operator + `))`
 
 	// boundaries for the secret
 	// \x60 = `
@@ -88,8 +84,7 @@ func generateSemiGenericRegexIncludingXml(identifiers []string, secretRegex stri
 		writeIdentifiersIncludingXml(&sb, identifiers)
 		sb.WriteString(identifierCaseInsensitiveSuffix)
 	}
-	sb.WriteString(xmlAttributeValuePair)
-	sb.WriteString(optionalOperator)
+	sb.WriteString(operatorOrXmlValue)
 	sb.WriteString(secretPrefix)
 	sb.WriteString(secretRegex)
 	sb.WriteString(secretSuffixIncludingXml)

--- a/engine/rules/ruledefine/utils.go
+++ b/engine/rules/ruledefine/utils.go
@@ -24,7 +24,7 @@ const (
 	operator = `(?:=|>|:{1,3}=|\|\||:|=>|\?=|,)`
 
 	// operatorOrXmlValue requires either a normal assignment operator (YAML, JSON, plist `>` after
-	// <string>, etc.) or XML attribute value="..." (e.g. <Parameter name="github_token" value="..."/>).
+	// <string>) or XML attribute value="..." (<Parameter name="github_token" value="..."/>).
 	operatorOrXmlValue = `(?:(?:\s*value\s*=\s*["'])|(?:` + operator + `))`
 
 	// boundaries for the secret

--- a/engine/rules/ruledefine/utils.go
+++ b/engine/rules/ruledefine/utils.go
@@ -19,9 +19,17 @@ const (
 	identifierSuffix                = `)(?:[ \t\w.-]{0,20})[\s'"]{0,3}`
 	identifierSuffixIncludingXml    = `)(?:[0-9a-z\-_\t .]{0,20})(?:<\/key>\s{0,10}<string)?(?:[\s|']|[\s|"]){0,3}`
 
+	// xmlAttributeValuePair bridges identifier (e.g. name="github_token") to the secret in
+	// <Parameter name="..." value="secret"/> and similar patterns.
+	xmlAttributeValuePair = `(?:\s*value\s*=\s*["'])?`
+
 	// commonly used assignment operators or function call
 	// operator = `(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)`
 	operator = `(?:=|>|:{1,3}=|\|\||:|=>|\?=|,)`
+
+	// optionalOperator allows YAML/JSON (operator required or absorbed by secretPrefix) and XML
+	// Parameter lines where xmlAttributeValuePair consumed value=" and the secret follows immediately.
+	optionalOperator = `(?:` + operator + `)?`
 
 	// boundaries for the secret
 	// \x60 = `
@@ -80,7 +88,8 @@ func generateSemiGenericRegexIncludingXml(identifiers []string, secretRegex stri
 		writeIdentifiersIncludingXml(&sb, identifiers)
 		sb.WriteString(identifierCaseInsensitiveSuffix)
 	}
-	sb.WriteString(operator)
+	sb.WriteString(xmlAttributeValuePair)
+	sb.WriteString(optionalOperator)
 	sb.WriteString(secretPrefix)
 	sb.WriteString(secretRegex)
 	sb.WriteString(secretSuffixIncludingXml)


### PR DESCRIPTION
**Proposed Changes**

- The Generic-Api-Key regex (from `generateSemiGenericRegexIncludingXml`) expected an assignment operator (:, =, etc.) right after the keyword and its suffix. That matches YAML like token: ghp_... and plist-style <key>...</key><string>..., but not typical config XML: <Parameter name="github_token" value="ghp_..."/>, where the secret is separated by another attribute (value="...) instead of an operator immediately after token or secret.

```xml
    <Parameter name="github_token" value="ghp_1234567890abcdefghijklmnopqrstuv"/>
    <Parameter name="jwt_secret" value="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"/>
```

- Added in `utils.go`, an optional bridge value=" (operatorOrXmlValue) before the operator, so that after matching the identifier (e.g. token in github_token) and the closing quote, the pattern can consume value=" and then match the secret (same idea as the existing plist bridge, but for attribute-style XML).

**Checklist**

- [x] I covered my changes with tests.
- [ ] I Updated the documentation that is affected by my changes:
  - [ ] Change in the CLI arguments
  - [ ] Change in the configuration file

I submit this contribution under the Apache-2.0 license.
