### PR TITLE
fix(release): wire version into release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
           GOOS: linux
           GOARCH: amd64
         run: |
-          go build -ldflags "-s -w -X github.com/checkmarx/2ms/cmd.Version=$VERSION" -a -installsuffix cgo -o dist/2ms main.go
+          go build -ldflags "-s -w -X github.com/checkmarx/2ms/v5/cmd.Version=$VERSION" -a -installsuffix cgo -o dist/2ms main.go
           zip -j dist/linux-amd64.zip dist/2ms
           rm dist/2ms
       - name: Compile for Linux arm64
@@ -81,7 +81,7 @@ jobs:
           GOOS: linux
           GOARCH: arm64
         run: |
-          go build -ldflags "-s -w -X github.com/checkmarx/2ms/cmd.Version=$VERSION" -a -installsuffix cgo -o dist/2ms main.go
+          go build -ldflags "-s -w -X github.com/checkmarx/2ms/v5/cmd.Version=$VERSION" -a -installsuffix cgo -o dist/2ms main.go
           zip -j dist/linux-arm64.zip dist/2ms
           rm dist/2ms
 
@@ -92,7 +92,7 @@ jobs:
           GOOS: darwin
           GOARCH: amd64
         run: |
-          go build -ldflags "-s -w -X github.com/checkmarx/2ms/cmd.Version=$VERSION" -a -installsuffix cgo -o dist/2ms main.go
+          go build -ldflags "-s -w -X github.com/checkmarx/2ms/v5/cmd.Version=$VERSION" -a -installsuffix cgo -o dist/2ms main.go
           zip -j dist/macos-amd64.zip dist/2ms
           rm dist/2ms
 
@@ -103,7 +103,7 @@ jobs:
           GOOS: darwin
           GOARCH: arm64
         run: |
-          go build -ldflags "-s -w -X github.com/checkmarx/2ms/cmd.Version=$VERSION" -a -installsuffix cgo -o dist/2ms main.go
+          go build -ldflags "-s -w -X github.com/checkmarx/2ms/v5/cmd.Version=$VERSION" -a -installsuffix cgo -o dist/2ms main.go
           zip -j dist/macos-arm64.zip dist/2ms
           rm dist/2ms
 
@@ -114,7 +114,7 @@ jobs:
           GOOS: windows
           GOARCH: amd64
         run: |
-          go build -ldflags "-s -w -X github.com/checkmarx/2ms/cmd.Version=$VERSION" -a -installsuffix cgo -o dist/2ms.exe main.go
+          go build -ldflags "-s -w -X github.com/checkmarx/2ms/v5/cmd.Version=$VERSION" -a -installsuffix cgo -o dist/2ms.exe main.go
           zip -j dist/windows-amd64.zip dist/2ms.exe
           rm dist/2ms.exe
           
@@ -139,7 +139,7 @@ jobs:
           tag_name: ${{ needs.test.outputs.git_tag }}
           name: ${{ needs.test.outputs.git_tag }}
           body: ${{ needs.test.outputs.notes }}
-          target_commitish: ${{ steps.commit_and_push.outputs.latest_commit_hash }}
+          target_commitish: ${{ github.sha }}
           files: |
             dist/*.zip
 
@@ -152,6 +152,8 @@ jobs:
           tags: |
             checkmarx/2ms:latest
             checkmarx/2ms:${{ needs.test.outputs.version }}
+          build-args: |
+            VERSION=${{ needs.test.outputs.version }}
 
       - name: Update Docker repo description
         uses: peter-evans/dockerhub-description@e98e4d1628a5f3be2be7c231e50981aee98723ae # v4.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ FROM checkmarx/go:1.26.2-r0-9bc691851ef224@sha256:9bc691851ef2244d13b0b9ff48bd2d
 
 WORKDIR /app
 
+ARG VERSION=0.0.0
+
 #Copy go mod and sum files
 COPY go.mod .
 COPY go.sum .
@@ -17,7 +19,7 @@ RUN go mod download
 # COPY the source code as the last step
 COPY . .
 
-RUN GOOS=linux GOARCH=amd64 go build -buildvcs=false -ldflags="-s -w" -a -o /app/2ms .
+RUN GOOS=linux GOARCH=amd64 go build -buildvcs=false -ldflags="-s -w -X github.com/checkmarx/2ms/v5/cmd.Version=${VERSION}" -a -o /app/2ms .
 
 # Runtime image
 FROM checkmarx/git:2.54.0-r0-586cb59ae2f323@sha256:586cb59ae2f323b619760be099e9029828954aa6d5a230f0b0dc37a623894d6f


### PR DESCRIPTION
Closes #360

**Proposed Changes**

The release builds were passing `-X github.com/checkmarx/2ms/cmd.Version=$VERSION`, but the module path is `github.com/checkmarx/2ms/v5`, so the linker never updated the actual `cmd.Version` variable and released binaries kept the default `0.0.0`.

This PR:

- updates the release workflow linker paths to `github.com/checkmarx/2ms/v5/cmd.Version`,
- passes the computed release version into the Docker build,
- wires the Dockerfile build to set the same `cmd.Version` variable, and
- fixes the release workflow `target_commitish` expression to use `github.sha` instead of a missing step output, so the touched workflow passes `actionlint`.

Verification:

- `go test ./cmd -run TestVersionFlagExitZero -count=1`
- `go build -buildvcs=false -ldflags "-s -w -X github.com/checkmarx/2ms/v5/cmd.Version=9.8.7" -o artifacts-2ms-version-test.exe main.go; .\artifacts-2ms-version-test.exe --version` -> `2ms version 9.8.7`
- `go build -buildvcs=false -ldflags "-s -w -X github.com/checkmarx/2ms/cmd.Version=9.8.7" -o artifacts-2ms-version-wrong-path.exe main.go; .\artifacts-2ms-version-wrong-path.exe --version` -> `2ms version 0.0.0`
- `actionlint .github\workflows\release.yml`
- `git diff --check`

I also tried `go test ./...`. It still fails locally in Windows/environment-sensitive scan/e2e tests (`pkg` output ordering/expectation mismatch and `tests` temp `2ms` executable lookup), while the packages unrelated to those checks pass. I did not run a Docker image build locally to avoid the heavier image download/build path.

**Checklist**

- [x] I covered my changes with tests.
- [x] I Updated the documentation that is affected by my changes:
  - [ ] Change in the CLI arguments
  - [ ] Change in the configuration file

I submit this contribution under the Apache-2.0 license.

This was implemented with Codex assistance, with the source trace and final diff manually reviewed before sending.