### PR TITLE
fix: stop dropping the bytes between the chunk boundary and the read size

### DIFF
--- a/engine/chunk/chunk.go
+++ b/engine/chunk/chunk.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"sync"
 	"unicode"
 
@@ -134,26 +135,28 @@ func (c *Chunk) GetFileThreshold() int64 {
 
 // ReadChunk reads the next chunk of data from file
 func (c *Chunk) ReadChunk(reader *bufio.Reader, totalLines int) (string, error) {
-	// borrow a []bytes from the pool and seed it with raw data from file (up to chunk size + peek size)
-	rawData, ok := c.GetPeekedBuf()
-	if !ok {
-		return "", fmt.Errorf("expected *bytes.Buffer, got %T", rawData)
+	// look ahead without consuming (up to chunk size + peek size): whatever sits past the
+	// chunk boundary has to stay in the reader, otherwise the next call never sees it
+	rawData, err := reader.Peek(c.size + c.maxPeekSize)
+	if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, bufio.ErrBufferFull) {
+		return "", err
 	}
-	defer c.PutPeekedBuf(rawData)
-	n, err := reader.Read(*rawData)
-
-	var chunkStr string
-	// "Callers should always process the n > 0 bytes returned before considering the error err."
-	// https://pkg.go.dev/io#Reader
-	if n > 0 {
-		// only check the filetype at the start of file
-		if totalLines == 0 && ShouldSkipFile((*rawData)[:n]) {
-			return "", fmt.Errorf("skipping file: %w", ErrUnsupportedFileType)
-		}
-
-		chunkStr, err = c.generateChunk((*rawData)[:n])
+	if len(rawData) == 0 {
+		return "", io.EOF
 	}
+
+	// only check the filetype at the start of file
+	if totalLines == 0 && ShouldSkipFile(rawData) {
+		return "", fmt.Errorf("skipping file: %w", ErrUnsupportedFileType)
+	}
+
+	chunkStr, err := c.generateChunk(rawData)
 	if err != nil {
+		return "", err
+	}
+
+	// consume exactly what the chunk covers
+	if _, err := reader.Discard(len(chunkStr)); err != nil {
 		return "", err
 	}
 	return chunkStr, nil

--- a/engine/chunk/chunk_test.go
+++ b/engine/chunk/chunk_test.go
@@ -160,3 +160,47 @@ func TestGenerateChunk(t *testing.T) {
 		})
 	}
 }
+
+func TestReadChunkKeepsEveryByte(t *testing.T) {
+	// Arrange
+	testCases := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "boundary inside the peek window",
+			input: "abc\ndef\n\n\n\n\nghi\njkl",
+		},
+		{
+			name:  "boundary right after the chunk size",
+			input: "0123456789\n\nSECRET\n",
+		},
+		{
+			name:  "no boundary at all",
+			input: "abc\ndef\nghi\njkl\nmno\npqr\nstu\nvwx\nyz",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := New(WithSize(chunkSize), WithMaxPeekSize(maxPeekSize), WithSmallFileThreshold(smallFileThreshold))
+			reader := bufio.NewReaderSize(strings.NewReader(tc.input), chunkSize+maxPeekSize)
+
+			// Act
+			var scanned strings.Builder
+			totalLines := 0
+			for {
+				chunkStr, err := c.ReadChunk(reader, totalLines)
+				if err == io.EOF {
+					break
+				}
+				require.NoError(t, err)
+				totalLines += strings.Count(chunkStr, "\n")
+				scanned.WriteString(chunkStr)
+			}
+
+			// Assert
+			require.Equal(t, tc.input, scanned.String())
+		})
+	}
+}


### PR DESCRIPTION
**Proposed Changes**

`ReadChunk` reads up to `size + maxPeekSize` bytes out of the reader, and `generateChunk` then walks forward from `size` looking for a safe `\n\n` split. When it finds one it breaks and returns the prefix. The bytes that the read already consumed after that split are dropped on the floor. The next `ReadChunk` call starts from where the reader is now, which is past them, so that content never reaches the detectors.

Both loops (`engine.go:337` for filesystem, `plugins/confluence.go:370` for Confluence pages) call `ReadChunk` in a loop until `io.EOF`, so the gap is silent. Nothing errors, the scan just does not cover part of the file.

With a chunk size of 10 and a peek size of 5, scanning `"0123456789\n\nSECRET\n"` gives:

```
expected: "0123456789\n\nSECRET\n"
actual  : "0123456789\n\nRET\n"
```

"SEC" is gone. At the shipped defaults the window is 100KiB/25KiB, so any file over 100KiB can lose up to 25KiB per chunk, and a secret sitting in that region is not scanned.

The fix is to `Peek` rather than `Read`, and `Discard` exactly the number of bytes the returned chunk covers. That is what the "look-ahead" naming already implies. Both call sites build the reader with `bufio.NewReaderSize(..., GetSize()+GetMaxPeekSize())`, so the peek fits; `bufio.ErrBufferFull` is tolerated anyway, which means a caller with a smaller reader degrades to a shorter look-ahead instead of erroring.

Error behaviour is unchanged: empty input still returns `io.EOF`, and the unsupported-file-type check still runs on the first read with the same window of bytes.

Side note: `GetPeekedBuf`/`PutPeekedBuf` and `peekedBufPool` are no longer used by `ReadChunk`. I left them in place since they are exported and covered by tests. Happy to remove them if you would rather not carry them.

**Checklist**

- [x] I covered my changes with tests.
- [ ] I Updated the documentation that is affected by my changes:
  - [ ] Change in the CLI arguments
  - [ ] Change in the configuration file

`TestReadChunkKeepsEveryByte` reads a source to EOF and compares the concatenation of every chunk against the input. It fails on master for two of its three cases and passes with this change. `go test ./engine/... ./plugins/...` is green, and `gofmt` is clean.

I submit this contribution under the Apache-2.0 license.