### PR TITLE
fix: line content for repeated secrets and 10K byte lines

### DIFF
--- a/engine/config.go
+++ b/engine/config.go
@@ -37,6 +37,7 @@ var baseConfig = config.Config{
 				regexp.MustCompile(`verification-metadata\.xml`),
 				regexp.MustCompile(`Database.refactorlog`),
 				regexp.MustCompile(`(?:^|/)\.git$`),
+				regexp.MustCompile(`(?:^|/)secret\.doc$`),
 			},
 		},
 	},

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -552,16 +552,16 @@ func buildSecret(
 	}
 	value.Line = strings.ReplaceAll(value.Line, "\r", "")
 
-	lineContent, err := linecontent.GetLineContent(value.Line, value.Secret)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get line content for source %s: %w", item.GetSource(), err)
-	}
-
 	adjustedStartColumn := value.StartColumn
 	adjustedEndColumn := value.EndColumn
 	if hasNewline {
 		adjustedStartColumn--
 		adjustedEndColumn--
+	}
+
+	lineContent, err := linecontent.GetLineContent(value.Line, value.Secret, adjustedStartColumn)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get line content for source %s: %w", item.GetSource(), err)
 	}
 
 	secret := &secrets.Secret{

--- a/engine/linecontent/linecontent.go
+++ b/engine/linecontent/linecontent.go
@@ -11,7 +11,7 @@ const (
 	contextRightSizeLimit = 250
 )
 
-func GetLineContent(line, secret string) (string, error) {
+func GetLineContent(line, secret string, startColumn int) (string, error) {
 	lineSize := len(line)
 	if lineSize == 0 {
 		return "", fmt.Errorf("line empty")
@@ -27,8 +27,18 @@ func GetLineContent(line, secret string) (string, error) {
 		lineSize = lineMaxParseSize
 	}
 
-	// Find the secret's position in the line
-	secretStartIndex := strings.Index(line, secret)
+	// Find the secret's position in the line, searching from the match's start column
+	// onwards first so that repeated occurrences of secret in the line are disambiguated.
+	secretStartIndex := -1
+	hint := startColumn - 1
+	if hint >= 0 && hint < lineSize {
+		if idx := strings.Index(line[hint:], secret); idx != -1 {
+			secretStartIndex = hint + idx
+		}
+	}
+	if secretStartIndex == -1 {
+		secretStartIndex = strings.Index(line, secret)
+	}
 	if secretStartIndex == -1 {
 		// Secret not found, return truncated content based on context limits
 		maxSize := contextLeftSizeLimit + contextRightSizeLimit

--- a/engine/linecontent/linecontent.go
+++ b/engine/linecontent/linecontent.go
@@ -21,12 +21,13 @@ func GetLineContent(line, secret string, startColumn int) (string, error) {
 		return "", fmt.Errorf("secret empty")
 	}
 
-	// Truncate lineContent to max size, centering the window on startColumn so a secret
-	// far into a very long line isn't truncated away before it can be found.
+	// For lines > lineMaxParseSize, get just the necessary context around the secret
 	if lineSize > lineMaxParseSize {
+		matchStartIndex := startColumn - 1
 		windowStart := 0
-		if hint := startColumn - 1; hint >= 0 && hint < lineSize {
-			windowStart = max(hint-lineMaxParseSize/2, 0)
+		if matchStartIndex >= 0 && matchStartIndex < lineSize {
+			windowStart = max(matchStartIndex-lineMaxParseSize/2, 0)
+			// adjust line context window if windowStart+lineMaxParseSize would be higher than lineSize
 			windowStart = min(windowStart, lineSize-lineMaxParseSize)
 		}
 		line = line[windowStart : windowStart+lineMaxParseSize]
@@ -34,17 +35,13 @@ func GetLineContent(line, secret string, startColumn int) (string, error) {
 		startColumn -= windowStart
 	}
 
-	// Find the secret's position in the line, searching from the match's start column
-	// onwards first so that repeated occurrences of secret in the line are disambiguated.
+	// The same secret value can appear more than once on a line. Search for it at the relevant index for this secret instance
 	secretStartIndex := -1
-	hint := startColumn - 1
-	if hint >= 0 && hint < lineSize {
-		if idx := strings.Index(line[hint:], secret); idx != -1 {
-			secretStartIndex = hint + idx
+	matchStartIndex := startColumn - 1
+	if matchStartIndex >= 0 && matchStartIndex < lineSize {
+		if idx := strings.Index(line[matchStartIndex:], secret); idx != -1 {
+			secretStartIndex = matchStartIndex + idx
 		}
-	}
-	if secretStartIndex == -1 {
-		secretStartIndex = strings.Index(line, secret)
 	}
 	if secretStartIndex == -1 {
 		// Secret not found, return truncated content based on context limits

--- a/engine/linecontent/linecontent.go
+++ b/engine/linecontent/linecontent.go
@@ -21,10 +21,17 @@ func GetLineContent(line, secret string, startColumn int) (string, error) {
 		return "", fmt.Errorf("secret empty")
 	}
 
-	// Truncate lineContent to max size
+	// Truncate lineContent to max size, centering the window on startColumn so a secret
+	// far into a very long line isn't truncated away before it can be found.
 	if lineSize > lineMaxParseSize {
-		line = line[:lineMaxParseSize]
+		windowStart := 0
+		if hint := startColumn - 1; hint >= 0 && hint < lineSize {
+			windowStart = max(hint-lineMaxParseSize/2, 0)
+			windowStart = min(windowStart, lineSize-lineMaxParseSize)
+		}
+		line = line[windowStart : windowStart+lineMaxParseSize]
 		lineSize = lineMaxParseSize
+		startColumn -= windowStart
 	}
 
 	// Find the secret's position in the line, searching from the match's start column

--- a/engine/linecontent/linecontent_test.go
+++ b/engine/linecontent/linecontent_test.go
@@ -14,6 +14,7 @@ func TestGetLineContent(t *testing.T) {
 		name         string
 		line         string
 		secret       string
+		startColumn  int
 		expected     string
 		error        bool
 		errorMessage string
@@ -59,11 +60,12 @@ func TestGetLineContent(t *testing.T) {
 			error:    false,
 		},
 		{
-			name:     "Secret at the beginning with line size smaller than the parse limit",
-			line:     "start:" + dummySecret + strings.Repeat("A", lineMaxParseSize/2),
-			secret:   dummySecret,
-			expected: "start:" + dummySecret + strings.Repeat("A", contextRightSizeLimit),
-			error:    false,
+			name:        "Secret at the beginning with line size smaller than the parse limit",
+			line:        "start:" + dummySecret + strings.Repeat("A", lineMaxParseSize/2),
+			secret:      dummySecret,
+			startColumn: len("start:") + 1,
+			expected:    "start:" + dummySecret + strings.Repeat("A", contextRightSizeLimit),
+			error:       false,
 		},
 		{
 			name: "Secret found in middle with line size smaller than the parse limit",
@@ -74,43 +76,67 @@ func TestGetLineContent(t *testing.T) {
 				"A",
 				contextRightSizeLimit,
 			) + "end",
-			secret:   dummySecret,
-			expected: strings.Repeat("A", contextLeftSizeLimit) + dummySecret + strings.Repeat("A", contextRightSizeLimit),
-			error:    false,
+			secret:      dummySecret,
+			startColumn: len("start") + contextLeftSizeLimit + 1,
+			expected:    strings.Repeat("A", contextLeftSizeLimit) + dummySecret + strings.Repeat("A", contextRightSizeLimit),
+			error:       false,
 		},
 		{
-			name:     "Secret at the end with line size smaller than the parse limit",
-			line:     strings.Repeat("A", lineMaxParseSize/2) + dummySecret + ":end",
-			secret:   dummySecret,
-			expected: strings.Repeat("A", contextLeftSizeLimit) + dummySecret + ":end",
-			error:    false,
+			name:        "Secret at the end with line size smaller than the parse limit",
+			line:        strings.Repeat("A", lineMaxParseSize/2) + dummySecret + ":end",
+			secret:      dummySecret,
+			startColumn: lineMaxParseSize/2 + 1,
+			expected:    strings.Repeat("A", contextLeftSizeLimit) + dummySecret + ":end",
+			error:       false,
 		},
 		{
-			name:     "Secret at the beginning with line size larger than the parse limit",
-			line:     "start:" + dummySecret + strings.Repeat("A", lineMaxParseSize),
-			secret:   dummySecret,
-			expected: "start:" + dummySecret + strings.Repeat("A", contextRightSizeLimit),
-			error:    false,
+			name:        "Secret at the beginning with line size larger than the parse limit",
+			line:        "start:" + dummySecret + strings.Repeat("A", lineMaxParseSize),
+			secret:      dummySecret,
+			startColumn: len("start:") + 1,
+			expected:    "start:" + dummySecret + strings.Repeat("A", contextRightSizeLimit),
+			error:       false,
 		},
 		{
-			name:     "Secret found in middle with line size larger than the parse limit",
-			line:     "start" + strings.Repeat("A", contextLeftSizeLimit) + dummySecret + strings.Repeat("A", lineMaxParseSize) + "end",
-			secret:   dummySecret,
-			expected: strings.Repeat("A", contextLeftSizeLimit) + dummySecret + strings.Repeat("A", contextRightSizeLimit),
-			error:    false,
+			name:        "Secret found in middle with line size larger than the parse limit",
+			line:        "start" + strings.Repeat("A", contextLeftSizeLimit) + dummySecret + strings.Repeat("A", lineMaxParseSize) + "end",
+			secret:      dummySecret,
+			startColumn: len("start") + contextLeftSizeLimit + 1,
+			expected:    strings.Repeat("A", contextLeftSizeLimit) + dummySecret + strings.Repeat("A", contextRightSizeLimit),
+			error:       false,
 		},
 		{
-			name:     "Secret at the end with line size larger than the parse limit",
-			line:     strings.Repeat("A", lineMaxParseSize-100) + dummySecret + strings.Repeat("A", lineMaxParseSize),
-			secret:   dummySecret,
-			expected: strings.Repeat("A", contextLeftSizeLimit) + dummySecret + strings.Repeat("A", 100-len(dummySecret)),
-			error:    false,
+			name:        "Secret at the end with line size larger than the parse limit",
+			line:        strings.Repeat("A", lineMaxParseSize-100) + dummySecret + strings.Repeat("A", lineMaxParseSize),
+			secret:      dummySecret,
+			startColumn: lineMaxParseSize - 100 + 1,
+			expected:    strings.Repeat("A", contextLeftSizeLimit) + dummySecret + strings.Repeat("A", 100-len(dummySecret)),
+			error:       false,
+		},
+		{
+			name:        "Secret repeated on the same line uses the occurrence at startColumn",
+			line:        strings.Repeat("a", contextLeftSizeLimit) + dummySecret + strings.Repeat("b", contextLeftSizeLimit+contextRightSizeLimit) + dummySecret + strings.Repeat("c", contextRightSizeLimit),
+			secret:      dummySecret,
+			startColumn: contextLeftSizeLimit + len(dummySecret) + contextLeftSizeLimit + contextRightSizeLimit + 1,
+			expected:    strings.Repeat("b", contextLeftSizeLimit) + dummySecret + strings.Repeat("c", contextRightSizeLimit),
+			error:       false,
+		},
+		{
+			name: "Secret repeated with startColumn pointing at the containing match, not the secret itself",
+			line: strings.Repeat("a", contextLeftSizeLimit) + "KEY=" + dummySecret + strings.Repeat(
+				"b",
+				contextLeftSizeLimit+contextRightSizeLimit,
+			) + "KEY=" + dummySecret + strings.Repeat("c", contextRightSizeLimit),
+			secret:      dummySecret,
+			startColumn: contextLeftSizeLimit + len("KEY=") + len(dummySecret) + contextLeftSizeLimit + contextRightSizeLimit + 1,
+			expected:    strings.Repeat("b", contextLeftSizeLimit-len("KEY=")) + "KEY=" + dummySecret + strings.Repeat("c", contextRightSizeLimit),
+			error:       false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := GetLineContent(tt.line, tt.secret)
+			got, err := GetLineContent(tt.line, tt.secret, tt.startColumn)
 			if (err != nil) != tt.error {
 				t.Fatalf("GetLineContent() error = %v, wantErr %v", err, tt.error)
 			}

--- a/engine/linecontent/linecontent_test.go
+++ b/engine/linecontent/linecontent_test.go
@@ -110,7 +110,7 @@ func TestGetLineContent(t *testing.T) {
 			line:        strings.Repeat("A", lineMaxParseSize-100) + dummySecret + strings.Repeat("A", lineMaxParseSize),
 			secret:      dummySecret,
 			startColumn: lineMaxParseSize - 100 + 1,
-			expected:    strings.Repeat("A", contextLeftSizeLimit) + dummySecret + strings.Repeat("A", 100-len(dummySecret)),
+			expected:    strings.Repeat("A", contextLeftSizeLimit) + dummySecret + strings.Repeat("A", contextRightSizeLimit),
 			error:       false,
 		},
 		{
@@ -131,6 +131,20 @@ func TestGetLineContent(t *testing.T) {
 			startColumn: contextLeftSizeLimit + len("KEY=") + len(dummySecret) + contextLeftSizeLimit + contextRightSizeLimit + 1,
 			expected:    strings.Repeat("b", contextLeftSizeLimit-len("KEY=")) + "KEY=" + dummySecret + strings.Repeat("c", contextRightSizeLimit),
 			error:       false,
+		},
+		{
+			name: "Secret far beyond the parse limit is not truncated away",
+			line: strings.Repeat("x", lineMaxParseSize*3) + "PRE" + dummySecret + "POST" + strings.Repeat(
+				"y",
+				lineMaxParseSize,
+			),
+			secret:      dummySecret,
+			startColumn: lineMaxParseSize*3 + len("PRE") + 1,
+			expected: strings.Repeat("x", contextLeftSizeLimit-len("PRE")) + "PRE" + dummySecret + "POST" + strings.Repeat(
+				"y",
+				contextRightSizeLimit-len("POST"),
+			),
+			error: false,
 		},
 	}
 

--- a/engine/rules/ruledefine/utils.go
+++ b/engine/rules/ruledefine/utils.go
@@ -27,7 +27,7 @@ const (
 	// \x60 = `
 	secretPrefixUnique       = `\b(`
 	secretPrefix             = `[\x60'"\s=]{0,20}(`                                       //nolint:gosec // This is a regex pattern
-	secretSuffix             = `)(?:[\x60'"\s;]|\\[nr]|$)`                                //nolint:gosec // This is a regex pattern
+	SecretSuffix             = `)(?:[\x60'"\s;]|\\[nr]|$)`                                //nolint:gosec // This is a regex pattern
 	secretSuffixIncludingXml = `)(?:['|\"|\n|\r|\s|\x60|;]|\\n|\\r|$|\s{0,10}<\/string>)` //nolint:gosec // This is a regex pattern
 )
 
@@ -46,7 +46,7 @@ func generateSemiGenericRegex(identifiers []string, secretRegex string, isCaseIn
 	sb.WriteString(operator)
 	sb.WriteString(secretPrefix)
 	sb.WriteString(secretRegex)
-	sb.WriteString(secretSuffix)
+	sb.WriteString(SecretSuffix)
 	return regexp.MustCompile(sb.String())
 }
 
@@ -63,7 +63,7 @@ func generateUniqueTokenRegex(secretRegex string, isCaseInsensitive bool) *regex
 	}
 	sb.WriteString(secretPrefixUnique)
 	sb.WriteString(secretRegex)
-	sb.WriteString(secretSuffix)
+	sb.WriteString(SecretSuffix)
 	return regexp.MustCompile(sb.String())
 }
 

--- a/pkg/rules.go
+++ b/pkg/rules.go
@@ -8,3 +8,5 @@ import (
 func GetDefaultRules(includeDeprecated bool) []*ruledefine.Rule {
 	return rules.GetDefaultRules(includeDeprecated)
 }
+
+func GetRegexSuffix() string { return ruledefine.SecretSuffix }


### PR DESCRIPTION
<!--
Thanks for contributing to 2ms by offering a pull request.
-->

Closes #

**Proposed Changes**
Fixes to line content on these cases:
- Repeated secrets in same line all shared same lineContent, now line lineContent correctly wraps around each instance of the secret
- Lines bigger than 10k bytes had their line content always be the start of the line, now lineContent correctly wraps around the secret by looking at startColumn of the secret
<!--
Please describe the big picture of your changes here. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

**Checklist**

- [x] I covered my changes with tests.
- [ ] I Updated the documentation that is affected by my changes:
  - [ ] Change in the CLI arguments
  - [ ] Change in the configuration file

I submit this contribution under the Apache-2.0 license.
